### PR TITLE
Use less memory to create notifications

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
@@ -23,8 +23,9 @@ public class BgSparklineBuilder {
     private Context mContext;
 
     private static final String TAG = "BgSparklineBuilder";
-    private static final int NOTIFICATION_WIDTH_DP = 460; // 476 width minus 8 padding on each side
-    private static final int NOTIFICATION_HEIGHT_DP = 256;
+    private static final int NOTIFICATION_WIDTH_DP = 230; // 476 width minus 8 padding on each side is the native
+                                                          // resolution, but use less for lower memory requirements
+    private static final int NOTIFICATION_HEIGHT_DP = 128;
 
     private int width;
     private int height;
@@ -35,7 +36,7 @@ public class BgSparklineBuilder {
     private boolean showLowLine = false;
     private boolean showHighLine = false;
     private boolean showAxes = false;
-    private boolean useSmallDots = false;
+    private boolean useSmallDots = true;
 
     public BgSparklineBuilder setStart(long start) {
         this.start = start / BgGraphBuilder.FUZZER;
@@ -169,7 +170,7 @@ public class BgSparklineBuilder {
             lines.add(bgGraphBuilder.highLine());
         if (useSmallDots) {
             for(Line line: lines)
-                line.setPointRadius(1);
+                line.setPointRadius(2);
         }
         LineChartData lineData = new LineChartData(lines);
         if (showAxes) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -64,6 +64,8 @@ public class Notifications {
 
     int currentVolume;
     AudioManager manager;
+    Bitmap iconBitmap;
+    Bitmap notifiationBitmap;
 
     final int BgNotificationId = 001;
     final int calibrationNotificationId = 002;
@@ -334,7 +336,7 @@ public class Notifications {
         NotificationCompat.Builder b = new NotificationCompat.Builder(mContext);
         //b.setOngoing(true);
         b.setCategory(NotificationCompat.CATEGORY_STATUS);
-        String titleString = lastReading == null ? "BG Reading Unavailable" : (lastReading.displayValue(mContext) + " " + lastReading.slopeArrow());
+        String titleString = lastReading == null ? "BG Reading Unavailable" : (lastReading.displayValue(mContext) + " " + BgReading.slopeArrow(lastReading.calculated_value_slope));
         b.setContentTitle(titleString)
                 .setContentText("xDrip Data collection service is running.")
                 .setSmallIcon(R.drawable.ic_action_communication_invert_colors_on)
@@ -343,19 +345,20 @@ public class Notifications {
             b.setWhen(lastReading.timestamp);
             String deltaString = "Delta: " + bgGraphBuilder.unitizedDeltaString(lastReading.calculated_value - lastReadings.get(1).calculated_value);
             b.setContentText(deltaString);
-            b.setLargeIcon(new BgSparklineBuilder(mContext)
+            iconBitmap = new BgSparklineBuilder(mContext)
                     .setHeight(64)
                     .setWidth(64)
                     .setStart(System.currentTimeMillis() - 60000 * 60 * 3)
-                    .setBgGraphBuilder(new BgGraphBuilder(mContext))
-                    .build());
-
+                    .setBgGraphBuilder(bgGraphBuilder)
+                    .build();
+            b.setLargeIcon(iconBitmap);
             NotificationCompat.BigPictureStyle bigPictureStyle = new NotificationCompat.BigPictureStyle();
-            bigPictureStyle.bigPicture(new BgSparklineBuilder(mContext)
-                    .setBgGraphBuilder(new BgGraphBuilder(mContext))
+            notifiationBitmap = new BgSparklineBuilder(mContext)
+                    .setBgGraphBuilder(bgGraphBuilder)
                     .showHighLine()
                     .showLowLine()
-                    .build())
+                    .build();
+            bigPictureStyle.bigPicture(notifiationBitmap)
                     .setSummaryText(deltaString)
                     .setBigContentTitle(titleString);
             b.setStyle(bigPictureStyle);
@@ -371,6 +374,8 @@ public class Notifications {
                 NotificationManagerCompat
                         .from(mContext)
                         .notify(ongoingNotificationId, createOngoingNotification(bgGraphBuilder));
+                iconBitmap.recycle();
+                notifiationBitmap.recycle();
             }
         });
     }


### PR DESCRIPTION
recycle notification bitmaps and use a smaller bitmap for notification tray in order to reduce memory footprint.

Also fixes slope arrow.
