### PR TITLE
Corrected mg/dl bug in bgDelta.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/PebbleSync.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/PebbleSync.java
@@ -132,7 +132,7 @@ public class PebbleSync extends Service {
 
     public String bgDelta() {
         String deltaString;
-        if((PreferenceManager.getDefaultSharedPreferences(mContext).getString("units","mg/dl").compareTo("mg/dl") == 0)) {
+        if((PreferenceManager.getDefaultSharedPreferences(mContext).getString("units","mgdl").compareTo("mgdl") == 0)) {
             deltaString = String.format("%.0f", mBgReading.calculated_value_slope * 360000);
         } else {
             deltaString = String.format("%.1f", (mBgReading.calculated_value_slope * 360000)*Constants.MGDL_TO_MMOLL);


### PR DESCRIPTION
This corrects a bug in bgDelta that was not correctly determining the status of the units preference, and constantly sending the BG Delta with a decimal place.   The watch app is pretty stupid and uses the presence of a decimal place in either the BG or the Delta as indication of the units being mmol/l.

Pretty simple typo really, and I had corrected it a long time back, but it came back.  Anyway, this is just a single line and will make things easier for everyone using mg/dl.

mg/dl display on the pebble also requires a bug fix in the cgm-pebble-offline, which I have made in my repo at https://github.com/jstevensog/cgm-pebble-offline.
