### PR TITLE
Migration clean up

### DIFF
--- a/app/src/main/assets/migrations/27.sql
+++ b/app/src/main/assets/migrations/27.sql
@@ -1,3 +1,0 @@
-ALTER TABLE TransmitterData ADD COLUMN filtered_data DOUBLE;
-ALTER TABLE BgReadings ADD COLUMN filtered_data DOUBLE;
-ALTER TABLE BgReadings ADD COLUMN selected_filtered_data BOOLEAN;

--- a/app/src/main/assets/migrations/32.sql
+++ b/app/src/main/assets/migrations/32.sql
@@ -1,1 +1,1 @@
-ALTER TABLE BgReadings ADD COLUMN selected_filtered_data BOOLEAN;
+ALTER TABLE BgReadings ADD COLUMN filtered_data DOUBLE;


### PR DESCRIPTION
Removes duplicate creations of filtered_data columns in BgReading and TransmitterRawData.
Also removes selected_filtered_data column creation in BgReading.  This is not used.
Removed 27.sql
