### PR TITLE
SilentAlerts

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -59,6 +59,7 @@ public class EditAlertActivity extends ActivityWithMenu {
     EditText alertThreshold;
     EditText alertMp3File;
     EditText editSnooze;
+    EditText reraise;
 
     Button buttonalertMp3;
 
@@ -77,6 +78,7 @@ public class EditAlertActivity extends ActivityWithMenu {
     int startMinute = 0;
     int endHour = 23;
     int endMinute = 59;
+    int alertReraise = 1;
 
     int defaultSnooze;
 
@@ -136,6 +138,7 @@ public class EditAlertActivity extends ActivityWithMenu {
         viewTimeStart = (TextView) findViewById(R.id.view_alert_time_start);
         viewTimeEnd = (TextView) findViewById(R.id.view_alert_time_end);
         editSnooze = (EditText) findViewById(R.id.edit_snooze);
+        reraise = (EditText) findViewById(R.id.reraise);
 
         viewAlertOverrideText = (TextView) findViewById(R.id.view_alert_override_silent);
         checkboxAlertOverride = (CheckBox) findViewById(R.id.check_override_silent);
@@ -159,6 +162,7 @@ public class EditAlertActivity extends ActivityWithMenu {
             viewTimeStart.setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
             viewTimeEnd.setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
             editSnooze.setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
+            reraise.setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
             viewAlertOverrideText.setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
 
             ((TextView) findViewById(R.id.view_alert_text)).setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
@@ -166,6 +170,7 @@ public class EditAlertActivity extends ActivityWithMenu {
             ((TextView) findViewById(R.id.view_alert_default_snooze)).setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
             ((TextView) findViewById(R.id.view_alert_mp3_file)).setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
             ((TextView) findViewById(R.id.view_alert_time)).setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
+            ((TextView) findViewById(R.id.view_alert_time_between)).setTextSize(TypedValue.COMPLEX_UNIT_SP, 30);
 
         }
         SharedPreferences prefs =  PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
@@ -197,7 +202,7 @@ public class EditAlertActivity extends ActivityWithMenu {
             startMinute = 0;
             endHour = 23;
             endMinute = 59;
-
+            alertReraise = 1;
         } else {
             // We are editing an alert
             AlertType at = AlertType.get_alert(uuid);
@@ -227,6 +232,7 @@ public class EditAlertActivity extends ActivityWithMenu {
             startMinute = AlertType.time2Minutes(at.start_time_minutes);
             endHour = AlertType.time2Hours(at.end_time_minutes);
             endMinute = AlertType.time2Minutes(at.end_time_minutes);
+            alertReraise = at.minutes_between;
 
             if(uuid.equals(AlertType.LOW_ALERT_55)) {
                 // This is the 55 alert, can not be edited
@@ -235,8 +241,10 @@ public class EditAlertActivity extends ActivityWithMenu {
                 buttonalertMp3.setEnabled(false);
                 checkboxAllDay.setEnabled(false);
                 checkboxAlertOverride.setEnabled(false);
+                reraise.setEnabled(false);
             }
         }
+        reraise.setText(String.valueOf(alertReraise));
         alertMp3File.setKeyListener(null);
         viewHeader.setText(status);
         setDefaultSnoozeSpinner();
@@ -356,6 +364,21 @@ public class EditAlertActivity extends ActivityWithMenu {
                 if(!verifyThreshold(threshold)) {
                     return;
                 }
+                alertReraise = 1;
+                try {
+                    alertReraise = Integer.parseInt((reraise.getText().toString()));
+                }
+                catch (NumberFormatException nfe) {
+                    Log.e(TAG, "Invalid number", nfe);
+                }
+                if(alertReraise < 1) {
+                    Toast.makeText(getApplicationContext(), "Reraise Value must be 1 minute or greater", Toast.LENGTH_LONG).show();
+                    return;
+                } else if (alertReraise >= defaultSnooze) {
+                    Toast.makeText(getApplicationContext(), "Reraise Value must less than snooze length", Toast.LENGTH_LONG).show();
+                    return;
+                }
+
 
                 int timeStart = AlertType.toTime(startHour, startMinute);
                 int timeEnd = AlertType.toTime(endHour, endMinute);
@@ -380,9 +403,9 @@ public class EditAlertActivity extends ActivityWithMenu {
 ;
                 String mp3_file = audioPath;
                 if (uuid != null) {
-                    AlertType.update_alert(uuid, alertText.getText().toString(), above, threshold, allDay, 1, mp3_file, timeStart, timeEnd, overrideSilentMode, defaultSnooze);
+                    AlertType.update_alert(uuid, alertText.getText().toString(), above, threshold, allDay, alertReraise, mp3_file, timeStart, timeEnd, overrideSilentMode, defaultSnooze);
                 }  else {
-                    AlertType.add_alert(null, alertText.getText().toString(), above, threshold, allDay, 1, mp3_file, timeStart, timeEnd, overrideSilentMode, defaultSnooze);
+                    AlertType.add_alert(null, alertText.getText().toString(), above, threshold, allDay, alertReraise, mp3_file, timeStart, timeEnd, overrideSilentMode, defaultSnooze);
                 }
                 Intent returnIntent = new Intent();
                 setResult(RESULT_OK,returnIntent);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/ActiveBgAlert.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/ActiveBgAlert.java
@@ -18,13 +18,13 @@ import java.util.Date;
  */
 @Table(name = "ActiveBgAlert", id = BaseColumns._ID)
 public class ActiveBgAlert extends Model {
-    
+
     private final static String TAG = AlertPlayer.class.getSimpleName();
-    
+
     @Column(name = "alert_uuid")
     public String alert_uuid;
 
-    @Column(name = "is_snoozed") 
+    @Column(name = "is_snoozed")
     public boolean is_snoozed;
 
     @Column(name = "last_alerted_at") // Do we need this
@@ -38,14 +38,14 @@ public class ActiveBgAlert extends Model {
     @Column(name = "alert_started_at")
     public Long alert_started_at;
 
-    
+
     public boolean ready_to_alarm() {
         if(new Date().getTime() > next_alert_at) {
             return true;
         }
         return false;
     }
-    
+
     public static boolean alertSnoozeOver() {
         ActiveBgAlert activeBgAlert = getOnly();
         if (activeBgAlert == null) {
@@ -61,23 +61,23 @@ public class ActiveBgAlert extends Model {
         is_snoozed = true;
         save();
     }
-    
+
     public String toString() {
-        
+
         String alert_uuid = "alert_uuid: " + this.alert_uuid;
         String is_snoozed = "is_snoozed: " + this.is_snoozed;
         String last_alerted_at = "last_alerted_at: " + DateFormat.getDateTimeInstance(
                 DateFormat.LONG, DateFormat.LONG).format(new Date(this.last_alerted_at));
         String next_alert_at = "next_alert_at: " + DateFormat.getDateTimeInstance(
-                DateFormat.LONG, DateFormat.LONG).format(new Date(this.next_alert_at)); 
+                DateFormat.LONG, DateFormat.LONG).format(new Date(this.next_alert_at));
 
         String alert_started_at = "alert_started_at: " + DateFormat.getDateTimeInstance(
-                DateFormat.LONG, DateFormat.LONG).format(new Date(this.alert_started_at)); 
+                DateFormat.LONG, DateFormat.LONG).format(new Date(this.alert_started_at));
 
         return alert_uuid + " " + is_snoozed + " " + last_alerted_at + " "+ next_alert_at + " " + alert_started_at;
-        
+
     }
-    
+
     // We should only have at most one active alert at any given time.
     // This means that we will only have one of this objects at the database at any given time.
     // so we have the following static functions: getOnly, saveData, ClearData
@@ -87,24 +87,24 @@ public class ActiveBgAlert extends Model {
                 .from(ActiveBgAlert.class)
                 .orderBy("_ID asc")
                 .executeSingle();
-        
+
         if (aba != null) {
             Log.v(TAG, "ActiveBgAlert getOnly aba = " + aba.toString());
         } else {
             Log.v(TAG, "ActiveBgAlert getOnly returning null");
         }
-        
+
         return aba;
     }
-    
+
     public static AlertType alertTypegetOnly() {
         ActiveBgAlert aba = getOnly();
-        
+
         if (aba == null) {
             Log.v(TAG, "ActiveBgAlert: alertTypegetOnly returning null");
             return null;
         }
-        
+
         AlertType alert = AlertType.get_alert(aba.alert_uuid);
         if(alert == null) {
             Log.e(TAG, "alertTypegetOnly did not find the active alert as part of existing alerts. returning null");
@@ -117,7 +117,7 @@ public class ActiveBgAlert extends Model {
         }
         return alert;
     }
-    
+
     public static void Create(String alert_uuid, boolean is_snoozed, Long next_alert_at) {
         Log.e(TAG, "ActiveBgAlert Create called");
         ActiveBgAlert aba = getOnly();
@@ -131,7 +131,7 @@ public class ActiveBgAlert extends Model {
         aba.alert_started_at = new Date().getTime();
         aba.save();
     }
-    
+
     public static void ClearData() {
         Log.e(TAG, "ActiveBgAlert ClearData called");
         ActiveBgAlert aba = getOnly();
@@ -139,7 +139,7 @@ public class ActiveBgAlert extends Model {
             aba.delete();
         }
     }
-    
+
     public static void ClearIfSnoozeFinished() {
         Log.e(TAG, "ActiveBgAlert ClearIfSnoozeFinished called");
         ActiveBgAlert aba = getOnly();
@@ -150,7 +150,7 @@ public class ActiveBgAlert extends Model {
             }
         }
     }
-    
+
     // This function is called from ClockTick, when we play
     // If we were snoozed, we update the snooze to false, and update the start time.
     // return the time in minutes from the time playing the alert has started
@@ -163,7 +163,5 @@ public class ActiveBgAlert extends Model {
         Long timeSeconds =  (new Date().getTime() - alert_started_at) / 1000;
         return (int)Math.round(timeSeconds / 60.0);
     }
-    
-
 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -245,17 +245,13 @@ public class AlertPlayer {
                     builder.setSound(Uri.parse(audioPath));
                 }
             }
-        } else if (profile == ALERT_PROFILE_VIBRATE_ONLY ) {
-            //NotificationCompat.Builder mBuilder = notificationBuilder(title, content, intent);
-            builder.setVibrate(Notifications.vibratePattern);
-            NotificationManager mNotifyMgr = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
-            mNotifyMgr.cancel(Notifications.exportAlertNotificationId);
-            mNotifyMgr.notify(Notifications.exportAlertNotificationId, builder.build());
-        } else {
-            NotificationManager mNotifyMgr = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
-            mNotifyMgr.cancel(Notifications.exportAlertNotificationId);
-            mNotifyMgr.notify(Notifications.exportAlertNotificationId, builder.build());
         }
+        if (profile != ALERT_PROFILE_SILENT ) {
+            builder.setVibrate(Notifications.vibratePattern);
+        }
+        NotificationManager mNotifyMgr = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+        mNotifyMgr.cancel(Notifications.exportAlertNotificationId);
+        mNotifyMgr.notify(Notifications.exportAlertNotificationId, builder.build());
     }
 
     private void notificationDismiss(Context ctx) {

--- a/app/src/main/res/layout/activity_edit_alert.xml
+++ b/app/src/main/res/layout/activity_edit_alert.xml
@@ -119,6 +119,35 @@
                     </LinearLayout>
 
                     <LinearLayout
+                        android:orientation="horizontal"
+                        android:layout_width="fill_parent"
+                        android:layout_height="fill_parent"
+                        android:paddingTop="20dp">
+
+                        <TextView
+                            android:id="@+id/view_alert_time_between"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="left"
+                            android:text="Re-raise every \n x minutes if\n unaknowledged:"
+                            android:textSize="15sp"
+                            android:layout_gravity="center_vertical" />
+
+                        <EditText
+                            android:layout_width="80dp"
+                            android:layout_height="wrap_content"
+                            android:inputType="number"
+                            android:ems="10"
+                            android:id="@+id/reraise"
+                            android:autoText="false"
+                            android:text=""
+                            android:singleLine="true"
+                            android:textAlignment="center"
+                            android:textSize="15sp"
+                            android:layout_alignParentStart="true" />
+
+                    </LinearLayout>
+                    <LinearLayout
                         android:orientation="vertical"
                         android:layout_width="fill_parent"
                         android:layout_height="fill_parent"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -26,13 +26,14 @@
         <item>mgdl</item>
         <item>mmol</item>
     </string-array>
-    
+
 <!--     make sure to keep this values in sync with AlertPlayer.getAlertProfile -->
     <string-array name="BgAlertProfileEntries">
         <item>High</item>
         <item>ascending</item>
         <item>medium</item>
         <item>vibrate only</item>
+        <item>Silent</item>
     </string-array>
 
     <string-array name="BgAlertProfileValues">
@@ -40,8 +41,9 @@
         <item>ascending</item>
         <item>medium</item>
         <item>vibrate only</item>
+        <item>Silent</item>
     </string-array>
-    
+
     <string-array name="risingEntries">
         <item>2 mgdl (0.1 mmol)</item>
         <item>3 mgdl (0.16 mmol)</item>
@@ -51,7 +53,7 @@
         <item>2</item>
         <item>3</item>
     </string-array>
-    
+
     <string-array name="alertType">
         <item>System Sound/Alarm</item>
         <item>Custom Sound/Alarm</item>


### PR DESCRIPTION
@tzachi-dar and @swissalpine let me know if this is what you were thinking

A rundown:

When setting alerts you get to choose how long it will be until it will consider re-raising. This value must be at least 1 and less than the snooze amount (otherwise it would be confusing)

Also a silent mode in which notifications will be populated like normal, only no sounds will be made! Not even at 55 (as many share users still only want to hear noise coming from their dexcoms, or so I have been told)
