### PR TITLE
Minutes ago

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -17,6 +17,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.widget.DrawerLayout;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -203,8 +204,10 @@ public class Home extends ActivityWithMenu {
     }
 
     public void updateCurrentBgInfo() {
+        Log.d("Home", "called updateCurrentBgInfo()");
         final TextView notificationText = (TextView)findViewById(R.id.notices);
         notificationText.setText("");
+        notificationText.setTextColor(Color.RED);
         isBTWixel = CollectionServiceStarter.isBTWixel(getApplicationContext());
         isDexbridgeWixel = CollectionServiceStarter.isDexbridgeWixel(getApplicationContext());
         isBTShare = CollectionServiceStarter.isBTShare(getApplicationContext());
@@ -335,6 +338,7 @@ public class Home extends ActivityWithMenu {
         if (lastBgreading != null) {
             double estimate = 0;
             if ((new Date().getTime()) - (60000 * 11) - lastBgreading.timestamp > 0) {
+                notificationText.setTextColor(Color.RED);
                 notificationText.setText("Signal Missed");
                 if(!predictive){
                     estimate=lastBgreading.calculated_value;
@@ -345,6 +349,8 @@ public class Home extends ActivityWithMenu {
                 currentBgValueText.setPaintFlags(currentBgValueText.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
                 dexbridgeBattery.setPaintFlags(dexbridgeBattery.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
             } else {
+                notificationText.setTextColor(Color.WHITE);
+                notificationText.setText((System.currentTimeMillis()-lastBgreading.timestamp)/(60*1000) + " Minutes ago");
                 if(!predictive){
                     estimate=lastBgreading.calculated_value;
                     String stringEstimate = bgGraphBuilder.unitized_string(estimate);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -1,9 +1,5 @@
 package com.eveningoutpost.dexdrip;
 
-import android.app.Activity;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
-import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -15,39 +11,32 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
 import android.support.v4.widget.DrawerLayout;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
-import android.widget.Toast;
 
-import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 import com.eveningoutpost.dexdrip.Models.ActiveBluetoothDevice;
-import com.eveningoutpost.dexdrip.Models.AlertType;
 import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.Calibration;
-import com.eveningoutpost.dexdrip.Services.DexCollectionService;
 import com.eveningoutpost.dexdrip.Services.WixelReader;
 import com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.IdempotentMigrations;
 import com.eveningoutpost.dexdrip.UtilityModels.Intents;
-import com.eveningoutpost.dexdrip.UtilityModels.Notifications;
 import com.eveningoutpost.dexdrip.utils.ActivityWithMenu;
 import com.eveningoutpost.dexdrip.utils.DatabaseUtil;
+import com.nispok.snackbar.Snackbar;
+import com.nispok.snackbar.SnackbarManager;
+import com.nispok.snackbar.enums.SnackbarType;
+import com.nispok.snackbar.listeners.ActionClickListener;
 
 import java.io.File;
 import java.text.DecimalFormat;
 import java.util.Date;
 import java.util.List;
 
-import com.nispok.snackbar.Snackbar;
-import com.nispok.snackbar.SnackbarManager;
-import com.nispok.snackbar.enums.SnackbarType;
-import com.nispok.snackbar.listeners.ActionClickListener;
 import lecho.lib.hellocharts.ViewportChangeListener;
 import lecho.lib.hellocharts.gesture.ZoomType;
 import lecho.lib.hellocharts.model.Viewport;
@@ -204,7 +193,6 @@ public class Home extends ActivityWithMenu {
     }
 
     public void updateCurrentBgInfo() {
-        Log.d("Home", "called updateCurrentBgInfo()");
         final TextView notificationText = (TextView)findViewById(R.id.notices);
         notificationText.setText("");
         notificationText.setTextColor(Color.RED);
@@ -338,7 +326,6 @@ public class Home extends ActivityWithMenu {
         if (lastBgreading != null) {
             double estimate = 0;
             if ((new Date().getTime()) - (60000 * 11) - lastBgreading.timestamp > 0) {
-                notificationText.setTextColor(Color.RED);
                 notificationText.setText("Signal Missed");
                 if(!predictive){
                     estimate=lastBgreading.calculated_value;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -349,8 +349,10 @@ public class Home extends ActivityWithMenu {
                 currentBgValueText.setPaintFlags(currentBgValueText.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
                 dexbridgeBattery.setPaintFlags(dexbridgeBattery.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
             } else {
-                notificationText.setTextColor(Color.WHITE);
-                notificationText.setText((System.currentTimeMillis()-lastBgreading.timestamp)/(60*1000) + " Minutes ago");
+                if (notificationText.getText().length()==0){
+                    notificationText.setTextColor(Color.WHITE);
+                    notificationText.setText((System.currentTimeMillis()-lastBgreading.timestamp)/(60*1000) + " Minutes ago");
+                }
                 if(!predictive){
                     estimate=lastBgreading.calculated_value;
                     String stringEstimate = bgGraphBuilder.unitized_string(estimate);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -357,7 +357,7 @@ public class Home extends ActivityWithMenu {
             List<BgReading> bgReadingList = BgReading.latest(2);
             if(bgReadingList != null && bgReadingList.size() == 2) {
                 // same logic as in xDripWidget (refactor that to BGReadings to avoid redundancy / later inconsistencies)?
-                notificationText.append(" | "
+                notificationText.append("\n"
                         + bgGraphBuilder.unitizedDeltaString(lastBgreading.calculated_value - bgReadingList.get(1).calculated_value));
             }
             if(bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -338,7 +338,6 @@ public class Home extends ActivityWithMenu {
             } else {
                 if (notificationText.getText().length()==0){
                     notificationText.setTextColor(Color.WHITE);
-                    notificationText.setText((System.currentTimeMillis()-lastBgreading.timestamp)/(60*1000) + " Minutes ago");
                 }
                 if(!predictive){
                     estimate=lastBgreading.calculated_value;
@@ -354,6 +353,7 @@ public class Home extends ActivityWithMenu {
                     currentBgValueText.setText( stringEstimate + " " + BgReading.slopeArrow());
                 }
             }
+            notificationText.setText((System.currentTimeMillis()-lastBgreading.timestamp)/(60*1000) + " Minutes ago");
             if(bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
                 currentBgValueText.setTextColor(Color.parseColor("#C30909"));
             } else if(bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -353,7 +353,8 @@ public class Home extends ActivityWithMenu {
                     currentBgValueText.setText( stringEstimate + " " + BgReading.slopeArrow());
                 }
             }
-            notificationText.append("\n" + (System.currentTimeMillis() - lastBgreading.timestamp) / (60 * 1000) + " Minutes ago");
+            int minutes = (int)(System.currentTimeMillis() - lastBgreading.timestamp) / (60 * 1000);
+            notificationText.append("\n" + minutes + ((minutes==1)?" Minute ago":" Minutes ago"));
             List<BgReading> bgReadingList = BgReading.latest(2);
             if(bgReadingList != null && bgReadingList.size() == 2) {
                 // same logic as in xDripWidget (refactor that to BGReadings to avoid redundancy / later inconsistencies)?

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -353,7 +353,13 @@ public class Home extends ActivityWithMenu {
                     currentBgValueText.setText( stringEstimate + " " + BgReading.slopeArrow());
                 }
             }
-            notificationText.setText((System.currentTimeMillis()-lastBgreading.timestamp)/(60*1000) + " Minutes ago");
+            notificationText.append("\n" + (System.currentTimeMillis() - lastBgreading.timestamp) / (60 * 1000) + " Minutes ago");
+            List<BgReading> bgReadingList = BgReading.latest(2);
+            if(bgReadingList != null && bgReadingList.size() == 2) {
+                // same logic as in xDripWidget (refactor that to BGReadings to avoid redundancy / later inconsistencies)?
+                notificationText.append(" | "
+                        + bgGraphBuilder.unitizedDeltaString(lastBgreading.calculated_value - bgReadingList.get(1).calculated_value));
+            }
             if(bgGraphBuilder.unitized(estimate) <= bgGraphBuilder.lowMark) {
                 currentBgValueText.setTextColor(Color.parseColor("#C30909"));
             } else if(bgGraphBuilder.unitized(estimate) >= bgGraphBuilder.highMark) {


### PR DESCRIPTION
Show "x Minutes ago" in notification-area, if no other notification is set.

As There is a receiver for _ACTION_TIME_TICK_ that calls _updateCurrentBgInfo();_, it should at least update every full minute.

AFAIK the only time, there is a vadil updated reading and the minutes cannot be shown:

_"Possible bad calibration slope, please have a glass of water, wash hands, then recalibrate in a few!"_ can be set to notification area and then the bg is shown (displayCurrentInfo()). In this case, no "x Minutes ago" is shown, just the notification.
