### PR TITLE
Keeping backstack + abstract instead of RuntimeException

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.v4.widget.DrawerLayout;
 import android.util.Log;
 
+import com.eveningoutpost.dexdrip.Home;
 import com.eveningoutpost.dexdrip.NavDrawerBuilder;
 import com.eveningoutpost.dexdrip.NavigationDrawerFragment;
 import com.eveningoutpost.dexdrip.R;
@@ -49,7 +50,8 @@ public abstract class ActivityWithMenu extends Activity implements NavigationDra
             startActivity(intent_list.get(position));
             Set<String> categories = getIntent().getCategories();
             getIntent().getAction();
-            if(categories == null || ! (categories.contains("android.intent.category.LAUNCHER"))){
+            //do not close activity if it is the Launcher or "Home".
+            if(categories == null || ! (categories.contains("android.intent.category.LAUNCHER") || getMenuName().equalsIgnoreCase(Home.menu_name))){
                 finish();
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
@@ -44,7 +44,7 @@ public class ActivityWithMenu extends Activity implements NavigationDrawerFragme
     public void onNavigationDrawerItemSelected(int position) {
         if (position != menu_position) {
             startActivity(intent_list.get(position));
-            finish();
+            //finish();
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
@@ -17,7 +17,7 @@ import java.util.Set;
 /**
  * Created by stephenblack on 6/8/15.
  */
-public class ActivityWithMenu extends Activity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
+public abstract class ActivityWithMenu extends Activity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
     private NavDrawerBuilder navDrawerBuilder;
     private List<Intent> intent_list;
     private List<String> menu_option_list;
@@ -48,13 +48,12 @@ public class ActivityWithMenu extends Activity implements NavigationDrawerFragme
         if (position != menu_position) {
             startActivity(intent_list.get(position));
             Set<String> categories = getIntent().getCategories();
-            if(categories == null || ! categories.contains("android.intent.category.LAUNCHER")){
+            getIntent().getAction();
+            if(categories == null || ! (categories.contains("android.intent.category.LAUNCHER"))){
                 finish();
             }
         }
     }
 
-    public String getMenuName() { //NOTE: THIS MUST BE OVERRIDEN!!!
-        throw new RuntimeException("MUST OVERRIDE THIS!");
-    }
+    public abstract String getMenuName();
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
@@ -48,10 +48,8 @@ public abstract class ActivityWithMenu extends Activity implements NavigationDra
     public void onNavigationDrawerItemSelected(int position) {
         if (position != menu_position) {
             startActivity(intent_list.get(position));
-            Set<String> categories = getIntent().getCategories();
-            getIntent().getAction();
             //do not close activity if it is the Launcher or "Home".
-            if(categories == null || ! (categories.contains("android.intent.category.LAUNCHER") || getMenuName().equalsIgnoreCase(Home.menu_name))){
+            if (!getMenuName().equalsIgnoreCase(Home.menu_name)) {
                 finish();
             }
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
@@ -4,12 +4,15 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.widget.DrawerLayout;
+import android.util.Log;
 
 import com.eveningoutpost.dexdrip.NavDrawerBuilder;
 import com.eveningoutpost.dexdrip.NavigationDrawerFragment;
 import com.eveningoutpost.dexdrip.R;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Created by stephenblack on 6/8/15.
@@ -44,7 +47,10 @@ public class ActivityWithMenu extends Activity implements NavigationDrawerFragme
     public void onNavigationDrawerItemSelected(int position) {
         if (position != menu_position) {
             startActivity(intent_list.get(position));
-            //finish();
+            Set<String> categories = getIntent().getCategories();
+            if(categories == null || ! categories.contains("android.intent.category.LAUNCHER")){
+                finish();
+            }
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Created by stephenblack on 6/8/15.
  */
-public class ListActivityWithMenu extends ListActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
+public abstract class ListActivityWithMenu extends ListActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
     private NavDrawerBuilder navDrawerBuilder;
     private List<Intent> intent_list;
     private List<String> menu_option_list;
@@ -48,7 +48,5 @@ public class ListActivityWithMenu extends ListActivity implements NavigationDraw
         }
     }
 
-    public String getMenuName() { //NOTE: THIS MUST BE OVERRIDEN!!!
-        throw new RuntimeException("MUST OVERRIDE THIS!");
-    }
+    public abstract String getMenuName();
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
@@ -44,7 +44,7 @@ public class ListActivityWithMenu extends ListActivity implements NavigationDraw
     public void onNavigationDrawerItemSelected(int position) {
         if (position != menu_position) {
             startActivity(intent_list.get(position));
-            finish();
+            //finish();
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
@@ -44,7 +44,7 @@ public class ListActivityWithMenu extends ListActivity implements NavigationDraw
     public void onNavigationDrawerItemSelected(int position) {
         if (position != menu_position) {
             startActivity(intent_list.get(position));
-            //finish();
+            finish();
         }
     }
 


### PR DESCRIPTION
Back-Button won't close whole xDrip-App from Settings/ScanBT/, ... keeping Home on the "back stack".
Back-Button will still close if xDrip-Activity/Home is on top.

Also: Using "abstract" instead of RuntimeException. This will guarantee at compiletime, that the method is overridden, not cause Exceptions on runtime.
