### PR TITLE
Dex Transmitter ID Uppercase

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -141,6 +141,11 @@ public class DexCollectionService extends Service {
                     Log.w(TAG, "Removing from foreground");
                 }
             }
+            if(key.equals("dex_collection_method") || key.equals("dex_txid")){
+                //if the input method or ID changed, accept any new package once even if they seem duplicates
+                Log.d(TAG, "collection method or txID changed - setting lastdata to null");
+                lastdata = null;
+            }
         }
     };
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -306,11 +306,12 @@ public class DexCollectionService extends Service {
 
     private Integer convertSrc(final String Src) {
         Integer res = 0;
-        res |= getSrcValue(Src.charAt(0)) << 20;
-        res |= getSrcValue(Src.charAt(1)) << 15;
-        res |= getSrcValue(Src.charAt(2)) << 10;
-        res |= getSrcValue(Src.charAt(3)) << 5;
-        res |= getSrcValue(Src.charAt(4));
+        String tmpSrc = Src.toUpperCase();
+        res |= getSrcValue(tmpSrc.charAt(0)) << 20;
+        res |= getSrcValue(tmpSrc.charAt(1)) << 15;
+        res |= getSrcValue(tmpSrc.charAt(2)) << 10;
+        res |= getSrcValue(tmpSrc.charAt(3)) << 5;
+        res |= getSrcValue(tmpSrc.charAt(4));
         return res;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -114,6 +114,7 @@ public class DexCollectionService extends Service {
             stopSelf();
             return START_NOT_STICKY;
         }
+        lastdata = null;
         attemptConnection();
         return START_STICKY;
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -8,6 +8,7 @@ import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
@@ -17,6 +18,7 @@ import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
+import android.text.InputFilter;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -182,7 +184,7 @@ public class Preferences extends PreferenceActivity {
             final Preference predictiveBG = findPreference("predictive_bg");
             final Preference interpretRaw = findPreference("interpret_raw");
             final Preference shareKey = findPreference("share_key");
-            final Preference transmitterId = findPreference("dex_txid");
+            final EditTextPreference transmitterId = (EditTextPreference) findPreference("dex_txid");
             final Preference pebbleSync = findPreference("broadcast_to_pebble");
             final PreferenceCategory collectionCategory = (PreferenceCategory) findPreference("collection_category");
             final PreferenceCategory otherCategory = (PreferenceCategory) findPreference("other_category");
@@ -226,6 +228,8 @@ public class Preferences extends PreferenceActivity {
             bindPreferenceSummaryToValue(collectionMethod);
             bindPreferenceSummaryToValue(shareKey);
             bindPreferenceSummaryToValue(wifiRecievers);
+            bindPreferenceSummaryToValue(transmitterId);
+            transmitterId.getEditText().setFilters(new InputFilter[]{new InputFilter.AllCaps()});
             collectionMethod.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {


### PR DESCRIPTION
There was a likelihood that the user could enter the Dex TXID in
lowercase.  Thanks to AdrianLxM for the Preferences code to force all text
entered into this preference to UPPERCASE.  Also added code in
DexCollectionService to ensure the TXID is in uppercase, just to be on the
safe side.
