### PR TITLE
Tweak widget layout to support the Nexus 6 more gracefully

### DIFF
--- a/app/src/main/res/layout/x_drip_widget.xml
+++ b/app/src/main/res/layout/x_drip_widget.xml
@@ -11,27 +11,27 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:paddingLeft="10dp"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
             android:paddingTop="2dp"
-            android:paddingBottom="10dp"
-            android:paddingRight="10dp"
-        android:layout_gravity="center">
+            android:paddingBottom="10dp">
         <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+            android:orientation="horizontal">
 
             <TextView android:id="@+id/widgetBg"
                       android:layout_width="wrap_content"
-                      android:layout_height="fill_parent" android:layout_centerHorizontal="true"
-                      android:layout_centerVertical="true" android:text="---"
+                      android:layout_height="fill_parent"
+                      android:layout_gravity="center" android:text="---"
                       android:textColor="#ffffff" android:textSize="55sp"
                       android:layout_marginTop="-5dp"/>
             <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:paddingLeft="5dp">
+                    android:paddingStart="0dp"
+                    android:paddingEnd="0dp">
                 <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
The end of the arrow was getting cut off before.
