### PR TITLE
don't recycle null bitmaps

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -371,8 +371,10 @@ public class Notifications extends IntentService {
                 NotificationManagerCompat
                         .from(mContext)
                         .notify(ongoingNotificationId, createOngoingNotification(bgGraphBuilder, mContext));
-                iconBitmap.recycle();
-                notifiationBitmap.recycle();
+                if (iconBitmap != null)
+                    iconBitmap.recycle();
+                if (notifiationBitmap != null)
+                    notifiationBitmap.recycle();
             }
         });
     }


### PR DESCRIPTION
The bitmaps probably weren't set because there weren't enough readings in the DB, probably because of the 2h warmup period.  I don't think I've started a new install in the warmup period yet, so I never saw this issue.
