### PR TITLE
Make sure that navigation drawer intent list and names match each other.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavigationDrawerFragment.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavigationDrawerFragment.java
@@ -80,6 +80,7 @@ public class NavigationDrawerFragment extends Fragment {
         navDrawerBuilder = new NavDrawerBuilder(getActivity());
         List<String> menu_option_list = navDrawerBuilder.nav_drawer_options;
         String[] menu_options = menu_option_list.toArray(new String[menu_option_list.size()]);
+        intent_list = navDrawerBuilder.nav_drawer_intents;
 
         mDrawerListView.setAdapter(new ArrayAdapter<String>(
                 getActionBar().getThemedContext(),

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ActivityWithMenu.java
@@ -20,9 +20,6 @@ import java.util.Set;
  * Created by stephenblack on 6/8/15.
  */
 public abstract class ActivityWithMenu extends FragmentActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
-    private NavDrawerBuilder navDrawerBuilder;
-    private List<Intent> intent_list;
-    private List<String> menu_option_list;
     private int menu_position;
     private String menu_name;
     private NavigationDrawerFragment mNavigationDrawerFragment;
@@ -36,9 +33,8 @@ public abstract class ActivityWithMenu extends FragmentActivity implements Navig
     protected void onResume(){
         super.onResume();
         menu_name = getMenuName();
-        navDrawerBuilder = new NavDrawerBuilder(getApplicationContext());
-        menu_option_list = navDrawerBuilder.nav_drawer_options;
-        intent_list = navDrawerBuilder.nav_drawer_intents;
+        NavDrawerBuilder navDrawerBuilder = new NavDrawerBuilder(getApplicationContext());
+        List<String> menu_option_list = navDrawerBuilder.nav_drawer_options;
         menu_position = menu_option_list.indexOf(menu_name);
 
         mNavigationDrawerFragment = (NavigationDrawerFragment) getFragmentManager().findFragmentById(R.id.navigation_drawer);
@@ -47,6 +43,9 @@ public abstract class ActivityWithMenu extends FragmentActivity implements Navig
 
     @Override
     public void onNavigationDrawerItemSelected(int position) {
+        NavDrawerBuilder navDrawerBuilder = new NavDrawerBuilder(getApplicationContext());
+        List<String> menu_option_list = navDrawerBuilder.nav_drawer_options;
+        List<Intent> intent_list = navDrawerBuilder.nav_drawer_intents;
         if (position != menu_position) {
             startActivity(intent_list.get(position));
             //do not close activity if it is the Launcher or "Home".

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/ListActivityWithMenu.java
@@ -15,9 +15,6 @@ import java.util.List;
  * Created by stephenblack on 6/8/15.
  */
 public abstract class ListActivityWithMenu extends ListActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks {
-    private NavDrawerBuilder navDrawerBuilder;
-    private List<Intent> intent_list;
-    private List<String> menu_option_list;
     private int menu_position;
     private String menu_name;
     private NavigationDrawerFragment mNavigationDrawerFragment;
@@ -31,9 +28,8 @@ public abstract class ListActivityWithMenu extends ListActivity implements Navig
     protected void onResume(){
         super.onResume();
         menu_name = getMenuName();
-        navDrawerBuilder = new NavDrawerBuilder(getApplicationContext());
-        menu_option_list = navDrawerBuilder.nav_drawer_options;
-        intent_list = navDrawerBuilder.nav_drawer_intents;
+        NavDrawerBuilder  navDrawerBuilder = new NavDrawerBuilder(getApplicationContext());
+        List<String> menu_option_list = navDrawerBuilder.nav_drawer_options;
         menu_position = menu_option_list.indexOf(menu_name);
 
         mNavigationDrawerFragment = (NavigationDrawerFragment) getFragmentManager().findFragmentById(R.id.navigation_drawer);
@@ -42,6 +38,9 @@ public abstract class ListActivityWithMenu extends ListActivity implements Navig
 
     @Override
     public void onNavigationDrawerItemSelected(int position) {
+        NavDrawerBuilder navDrawerBuilder = new NavDrawerBuilder(getApplicationContext());
+        List<String> menu_option_list = navDrawerBuilder.nav_drawer_options;
+        List<Intent> intent_list = navDrawerBuilder.nav_drawer_intents;
         if (position != menu_position) {
             startActivity(intent_list.get(position));
             finish();


### PR DESCRIPTION
This fixes a bug where the user would choose one intent and another one would open.

To repro this do the following: start a new sensor, wait for two readings and choose double calibration. The StopSensor intent will open.

This happens since the list of intent changes but it was cached in a few places.
This removes the cache from a few places and make sure that on NavigationDrawerFragment intent_list is always updated when menu_option_list changes.

Signed-off-by: Tzachi Dar tzachi.dar@gmail.com
