### PR TITLE
Mongo update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'org.mongodb:mo'
+    compile 'org.mongodb:mongo-java-driver:3.0.3'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.getpebble:pebblekit:3.0.0'
     compile 'io.reactivex:rxjava:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'org.mongodb:mongo-java-driver:2.10.1'
+    compile 'org.mongodb:mongo-java-driver:3.0.2'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.getpebble:pebblekit:3.0.0'
     compile 'io.reactivex:rxjava:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'org.mongodb:mongo-java-driver:3.0.2'
+    compile 'org.mongodb:mo'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.getpebble:pebblekit:3.0.0'
     compile 'io.reactivex:rxjava:1.0.0'


### PR DESCRIPTION
Update mongo-java-driver to 3.0.3 (latest version) that should work with the upcoming upgrade of the free sandbox databases to version 3.0.

It seems to work on my current sandbox database (version 2.6) as for the direct upload as for the data that got queued while no data connection was possible.
-  I tested with the chrome-plugin as viewer, not nightscout/azure -> please test if you have nightscout/azure
-  Is any more update necessary to handle the actual update of the db to 3.0? 
