### PR TITLE
Fix sensor duration shown in system status. 

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
@@ -112,9 +112,9 @@ public class SystemStatus extends ActivityWithMenu {
             DateFormat df = new SimpleDateFormat();
             sensor_status.append(df.format(date));
             sensor_status.append(" (");
-            sensor_status.append((long) (System.currentTimeMillis() - sens.started_at) / (1000 * 60 * 60 * 24));
+            sensor_status.append((System.currentTimeMillis() - sens.started_at) / (1000 * 60 * 60 * 24));
             sensor_status.append("d ");
-            sensor_status.append((long)((System.currentTimeMillis() - sens.started_at)%(1000 * 60 * 60 * 24))/(1000*60*60));
+            sensor_status.append(((System.currentTimeMillis() - sens.started_at)%(1000 * 60 * 60 * 24))/(1000*60*60));
             sensor_status.append("h)");
         } else {
             sensor_status.append("not available");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
@@ -112,9 +112,9 @@ public class SystemStatus extends ActivityWithMenu {
             DateFormat df = new SimpleDateFormat();
             sensor_status.append(df.format(date));
             sensor_status.append(" (");
-            sensor_status.append((int) (System.currentTimeMillis() - sens.started_at) / (1000 * 60 * 60 * 24));
+            sensor_status.append((long) (System.currentTimeMillis() - sens.started_at) / (1000 * 60 * 60 * 24));
             sensor_status.append("d ");
-            sensor_status.append((int)((System.currentTimeMillis() - sens.started_at)%(1000 * 60 * 60 * 24))/(1000*60*60));
+            sensor_status.append((long)((System.currentTimeMillis() - sens.started_at)%(1000 * 60 * 60 * 24))/(1000*60*60));
             sensor_status.append("h)");
         } else {
             sensor_status.append("not available");


### PR DESCRIPTION
The duration(int) was overflowing when the sensor is more than 24 days old.

Before fix: Duration incorrectly shown as minus 24 days.
![before_fix](https://cloud.githubusercontent.com/assets/4600609/9197042/480bdb6e-4031-11e5-8856-86c379cbbce4.png)

After fix: Duration correctly shown as 25 days 3 hours.
![after_fix](https://cloud.githubusercontent.com/assets/4600609/9197040/48044584-4031-11e5-91a1-816e3f70d12f.png)
