### PR TITLE
Transmitter status home

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -5,13 +5,19 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.ColorFilter;
 import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.Shape;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.widget.DrawerLayout;
+import android.util.DisplayMetrics;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -148,6 +154,47 @@ public class Home extends ActivityWithMenu {
         }
 
         chart.setZoomType(ZoomType.HORIZONTAL);
+
+        //TODO: Adrian test Background
+
+        Drawable shape = new Drawable(){
+
+            @Override
+            public void draw(Canvas canvas) {
+
+                DisplayMetrics metrics = getApplicationContext().getResources().getDisplayMetrics();
+                int px = (int) (30 * (metrics.densityDpi / 160f));
+
+                Paint paint = new Paint();
+                paint.setTextSize(px);
+                paint.setAntiAlias(true);
+                paint.setColor(Color.parseColor("#FFFFAA"));
+                paint.setStyle(Paint.Style.STROKE);
+                paint.setAlpha(100);
+
+
+                canvas.drawText("transmitter battery", 10, chart.getHeight()/3 - (int)(1.2*px), paint );
+                canvas.drawText("rather low", 10, chart.getHeight()/3, paint );
+
+            }
+
+            @Override
+            public void setAlpha(int alpha) {
+
+            }
+
+            @Override
+            public void setColorFilter(ColorFilter cf) {
+
+            }
+
+            @Override
+            public int getOpacity() {
+                return 0;
+            }
+
+        };
+        chart.setBackground(shape);
 
         previewChart = (PreviewLineChartView) findViewById(R.id.chart_preview);
         previewChart.setZoomType(ZoomType.HORIZONTAL);
@@ -470,3 +517,4 @@ public class Home extends ActivityWithMenu {
         }
     }
 }
+

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -25,6 +25,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Constants;
 import com.eveningoutpost.dexdrip.Models.ActiveBluetoothDevice;
 import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.Calibration;
@@ -155,47 +156,40 @@ public class Home extends ActivityWithMenu {
 
         chart.setZoomType(ZoomType.HORIZONTAL);
 
-        //TODO: Adrian test Background
+        //Transmitter Battery Level
+        final Sensor sensor = Sensor.currentSensor();
+        if (sensor != null && sensor.latest_battery_level != 0 && sensor.latest_battery_level <= Constants.TRANSMITTER_BATTERY_LOW) {
+            Drawable background = new Drawable() {
 
-        Drawable shape = new Drawable(){
+                @Override
+                public void draw(Canvas canvas) {
 
-            @Override
-            public void draw(Canvas canvas) {
+                    DisplayMetrics metrics = getApplicationContext().getResources().getDisplayMetrics();
+                    int px = (int) (30 * (metrics.densityDpi / 160f));
+                    Paint paint = new Paint();
+                    paint.setTextSize(px);
+                    paint.setAntiAlias(true);
+                    paint.setColor(Color.parseColor("#FFFFAA"));
+                    paint.setStyle(Paint.Style.STROKE);
+                    paint.setAlpha(100);
+                    canvas.drawText("transmitter battery", 10, chart.getHeight() / 3 - (int) (1.2 * px), paint);
+                    if(sensor.latest_battery_level <= Constants.TRANSMITTER_BATTERY_EMPTY){
+                        paint.setTextSize((int)(px*1.5));
+                        canvas.drawText("EMPTY !!!", 10, chart.getHeight() / 3, paint);
+                    } else {
+                        canvas.drawText("rather low", 10, chart.getHeight() / 3, paint);
+                    }
+                }
 
-                DisplayMetrics metrics = getApplicationContext().getResources().getDisplayMetrics();
-                int px = (int) (30 * (metrics.densityDpi / 160f));
-
-                Paint paint = new Paint();
-                paint.setTextSize(px);
-                paint.setAntiAlias(true);
-                paint.setColor(Color.parseColor("#FFFFAA"));
-                paint.setStyle(Paint.Style.STROKE);
-                paint.setAlpha(100);
-
-
-                canvas.drawText("transmitter battery", 10, chart.getHeight()/3 - (int)(1.2*px), paint );
-                canvas.drawText("rather low", 10, chart.getHeight()/3, paint );
-
-            }
-
-            @Override
-            public void setAlpha(int alpha) {
-
-            }
-
-            @Override
-            public void setColorFilter(ColorFilter cf) {
-
-            }
-
-            @Override
-            public int getOpacity() {
-                return 0;
-            }
-
-        };
-        chart.setBackground(shape);
-
+                @Override
+                public void setAlpha(int alpha) {}
+                @Override
+                public void setColorFilter(ColorFilter cf) {}
+                @Override
+                public int getOpacity() {return 0;}
+            };
+            chart.setBackground(background);
+        }
         previewChart = (PreviewLineChartView) findViewById(R.id.chart_preview);
         previewChart.setZoomType(ZoomType.HORIZONTAL);
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -173,9 +173,9 @@ public class Home extends ActivityWithMenu {
                     canvas.drawText("transmitter battery", 10, chart.getHeight() / 3 - (int) (1.2 * px), paint);
                     if(sensor.latest_battery_level <= Constants.TRANSMITTER_BATTERY_EMPTY){
                         paint.setTextSize((int)(px*1.5));
-                        canvas.drawText("EMPTY !!!", 10, chart.getHeight() / 3, paint);
+                        canvas.drawText("VERY LOW", 10, chart.getHeight() / 3, paint);
                     } else {
-                        canvas.drawText("rather low", 10, chart.getHeight() / 3, paint);
+                        canvas.drawText("low", 10, chart.getHeight() / 3, paint);
                     }
                 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -10,8 +10,6 @@ import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.ShapeDrawable;
-import android.graphics.drawable.shapes.Shape;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Constants.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/ImportedLibraries/dexcom/Constants.java
@@ -55,6 +55,8 @@ public class Constants {
     public final static int EGV_NOISE_MASK = 112;
     public final static float MG_DL_TO_MMOL_L = 0.05556f;
     public final static int CRC_LEN = 2;
+    public static final int TRANSMITTER_BATTERY_LOW = 210;
+    public static final int TRANSMITTER_BATTERY_EMPTY = 207;
 
     public enum BATTERY_STATES {
         NONE,

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Sensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Sensor.java
@@ -27,6 +27,7 @@ public class Sensor extends Model {
     public long stopped_at;
 
 //    @Expose
+    //latest minimal battery level
     @Column(name = "latest_battery_level")
     public int latest_battery_level;
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -492,7 +492,7 @@ public class DexCollectionService extends Service {
             return;
         }
 
-        sensor.latest_battery_level = transmitterData.sensor_battery_level;
+        sensor.latest_battery_level = Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level);
         sensor.save();
 
         BgReading.create(transmitterData.raw_data, transmitterData.filtered_data, this, timestamp);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -492,7 +492,7 @@ public class DexCollectionService extends Service {
             return;
         }
 
-        sensor.latest_battery_level = Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level);
+        sensor.latest_battery_level = (sensor.latest_battery_level!=0)?Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level):transmitterData.sensor_battery_level;
         sensor.save();
 
         BgReading.create(transmitterData.raw_data, transmitterData.filtered_data, this, timestamp);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
@@ -411,7 +411,7 @@ public class WixelReader  extends Thread {
             Sensor sensor = Sensor.currentSensor();
             if (sensor != null) {
                 BgReading bgReading = BgReading.create(transmitterData.raw_data, filtered_data, mContext, CaptureTime);
-                sensor.latest_battery_level = Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level);
+                sensor.latest_battery_level = (sensor.latest_battery_level!=0)?Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level):transmitterData.sensor_battery_level;;
                 sensor.save();
             } else {
                 Log.w(TAG, "No Active Sensor, Data only stored in Transmitter Data");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
@@ -411,7 +411,7 @@ public class WixelReader  extends Thread {
             Sensor sensor = Sensor.currentSensor();
             if (sensor != null) {
                 BgReading bgReading = BgReading.create(transmitterData.raw_data, filtered_data, mContext, CaptureTime);
-                sensor.latest_battery_level = transmitterData.sensor_battery_level;
+                sensor.latest_battery_level = Math.min(sensor.latest_battery_level, transmitterData.sensor_battery_level);
                 sensor.save();
             } else {
                 Log.w(TAG, "No Active Sensor, Data only stored in Transmitter Data");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
@@ -19,6 +19,7 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.eveningoutpost.dexdrip.ImportedLibraries.dexcom.Constants;
 import com.eveningoutpost.dexdrip.Models.ActiveBluetoothDevice;
 import com.eveningoutpost.dexdrip.Models.TransmitterData;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
@@ -125,9 +126,9 @@ public class SystemStatus extends ActivityWithMenu {
         } else {
             transmitter_status_view.setText("" + td.sensor_battery_level);
 
-            if (td.sensor_battery_level <= 207) {
+            if (td.sensor_battery_level <= Constants.TRANSMITTER_BATTERY_EMPTY) {
                 transmitter_status_view.append(" - empty");
-            } else if (td.sensor_battery_level <= 210) {
+            } else if (td.sensor_battery_level <= Constants.TRANSMITTER_BATTERY_LOW) {
                 transmitter_status_view.append(" - ok - rather low");
                 transmitter_status_view.append("\n(experimental interpretation)");
             } else {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/SystemStatus.java
@@ -127,9 +127,9 @@ public class SystemStatus extends ActivityWithMenu {
             transmitter_status_view.setText("" + td.sensor_battery_level);
 
             if (td.sensor_battery_level <= Constants.TRANSMITTER_BATTERY_EMPTY) {
-                transmitter_status_view.append(" - empty");
+                transmitter_status_view.append(" - very low");
             } else if (td.sensor_battery_level <= Constants.TRANSMITTER_BATTERY_LOW) {
-                transmitter_status_view.append(" - ok - rather low");
+                transmitter_status_view.append(" - low");
                 transmitter_status_view.append("\n(experimental interpretation)");
             } else {
                 transmitter_status_view.append(" - ok");


### PR DESCRIPTION
- Added Transmitter Battery Status to Homescreen
- It will be in the background - chart is drawn on top (-> should not affect visibility much)
- Sensor will now have lowest transmitter battery level reported so far for this sensor period.
- Moved constants for thresholds to class Constants.java (avoid redundancy/inconsistency)

This is how it looks like:

![low](http://up.picr.de/22855668xi.png)
![empty](http://up.picr.de/22856045si.png)

Should we add "experimental interpretation" to the "rather low"-status like in the SystemStatus?
Feedback highly appreciated! :)
