### PR TITLE
notifications to front with semitransparent backgr

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -25,19 +25,6 @@
                 android:paddingBottom="0dp" tools:context=".Home"
                 android:layout_marginTop="0dp">
 
-                <TextView
-                    android:layout_width="900dp"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="#C30909"
-                    android:id="@+id/notices"
-                    android:background="#212121"
-                    android:paddingEnd="10dp"
-                    android:paddingStart="10dp"
-                    android:gravity="left|top"
-                    android:layout_alignParentLeft="true"
-                    android:layout_alignParentTop="true"
-                    android:text="Alerts and messages" />
 
                 <lecho.lib.hellocharts.view.LineChartView
                     android:id="@+id/chart"
@@ -49,9 +36,23 @@
                 </lecho.lib.hellocharts.view.LineChartView>
 
                 <TextView
+                    android:layout_width="900dp"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="#C30909"
+                    android:id="@+id/notices"
+                    android:background="#40212121"
+                    android:paddingEnd="10dp"
+                    android:paddingStart="10dp"
+                    android:gravity="left|top"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignParentTop="true"
+                    android:text="Alerts and messages" />
+
+                <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:background="#212121"
+                    android:background="#40212121"
                     android:id="@+id/currentBgValueRealTime"
                     android:gravity="right"
                     android:layout_alignParentEnd="true"


### PR DESCRIPTION
Notification area was cut off, if much information was shown:
![screenshot_2015-09-08-13-35-17](https://cloud.githubusercontent.com/assets/9692866/9736755/663700c8-5643-11e5-86d4-3892496f782e.png)
(Screenshot from Matthias/@ceben80 - and thanks for reporting)

Now it is in front with semitransparent background:
![screenshot_2015-09-08-15-57-01](https://cloud.githubusercontent.com/assets/9692866/9736826/cb05e0aa-5643-11e5-96a4-6e03b3b96d57.png)
