### PR TITLE
Add support for Bluetooth and Wifi Wixels running simultaneously

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -70,6 +70,7 @@ public class Home extends ActivityWithMenu {
     private TextView                 dexbridgeBattery;
     private TextView                 currentBgValueText;
     private TextView                 notificationText;
+    private boolean                  alreadyDisplayedBgInfoCommon = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -204,6 +205,7 @@ public class Home extends ActivityWithMenu {
         isWifiBluetoothWixel = CollectionServiceStarter.isWifiandBTWixel(getApplicationContext());
         isBTShare = CollectionServiceStarter.isBTShare(getApplicationContext());
         isWifiWixel = CollectionServiceStarter.isWifiWixel(getApplicationContext());
+        alreadyDisplayedBgInfoCommon = false; // reset flag
         if (isBTShare) {
             updateCurrentBgInfoForBtShare(notificationText);
         }
@@ -244,6 +246,9 @@ public class Home extends ActivityWithMenu {
     }
 
     private void updateCurrentBgInfoCommon(TextView notificationText) {
+        if (alreadyDisplayedBgInfoCommon) return; // with bluetooth and wifi, skip second time
+        alreadyDisplayedBgInfoCommon = true;
+
         final boolean isSensorActive = Sensor.isActive();
         if(!isSensorActive){
             notificationText.setText("Now start your sensor");

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -61,6 +61,7 @@ public class Home extends ActivityWithMenu {
     private boolean isDexbridgeWixel;
     private boolean isBTShare;
     private boolean isWifiWixel;
+    private boolean isWifiBluetoothWixel;
     private BroadcastReceiver _broadcastReceiver;
     private BroadcastReceiver newDataReceiver;
     private NavigationDrawerFragment mNavigationDrawerFragment;
@@ -200,15 +201,16 @@ public class Home extends ActivityWithMenu {
         notificationText.setTextColor(Color.RED);
         isBTWixel = CollectionServiceStarter.isBTWixel(getApplicationContext());
         isDexbridgeWixel = CollectionServiceStarter.isDexbridgeWixel(getApplicationContext());
+        isWifiBluetoothWixel = CollectionServiceStarter.isWifiandBTWixel(getApplicationContext());
         isBTShare = CollectionServiceStarter.isBTShare(getApplicationContext());
         isWifiWixel = CollectionServiceStarter.isWifiWixel(getApplicationContext());
         if (isBTShare) {
             updateCurrentBgInfoForBtShare(notificationText);
         }
-        if (isBTWixel || isDexbridgeWixel) {
+        if (isBTWixel || isDexbridgeWixel || isWifiBluetoothWixel) {
             updateCurrentBgInfoForBtBasedWixel(notificationText);
         }
-        if (isWifiWixel) {
+        if (isWifiWixel || isWifiBluetoothWixel) {
             updateCurrentBgInfoForWifiWixel(notificationText);
         }
         if (prefs.getLong("alerts_disabled_until", 0) > new Date().getTime()) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/TransmitterData.java
@@ -58,7 +58,7 @@ public class TransmitterData extends Model {
 
             randomDelay(100, 1000);
             TransmitterData lastTransmitterData = TransmitterData.last();
-            if (lastTransmitterData != null && lastTransmitterData.raw_data == Integer.parseInt(data[0]) && Math.abs(lastTransmitterData.timestamp - timestamp) < (10000)) { //Stop allowing duplicate data, its bad!
+            if (lastTransmitterData != null && lastTransmitterData.raw_data == Integer.parseInt(data[0]) && Math.abs(lastTransmitterData.timestamp - timestamp) < (100000)) { //Stop allowing duplicate data, its bad! // jamorham: increased to 100 seconds for additional safety with multiple collection modes operating at the same time
                 return null;
             }
             if (data.length > 1) { transmitterData.sensor_battery_level = Integer.parseInt(data[1]); }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -98,7 +98,8 @@ public class DexCollectionService extends Service {
             stopSelf();
             return START_NOT_STICKY;
         }
-        if (CollectionServiceStarter.isBTWixel(getApplicationContext()) || CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())) {
+        if (CollectionServiceStarter.isBTWixel(getApplicationContext()) || CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())
+                || CollectionServiceStarter.isWifiandBTWixel(getApplicationContext())) {
             setFailoverTimer();
         } else {
             stopSelf();
@@ -144,7 +145,8 @@ public class DexCollectionService extends Service {
     }
 
     public void setRetryTimer() {
-        if (CollectionServiceStarter.isBTWixel(getApplicationContext()) || CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())) {
+        if (CollectionServiceStarter.isBTWixel(getApplicationContext()) || CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())
+                || CollectionServiceStarter.isWifiandBTWixel(getApplicationContext())) {
             long retry_in = (1000 * 65);
             Log.d(TAG, "setRetryTimer: Restarting in: " + (retry_in/1000)  + " seconds");
             Calendar calendar = Calendar.getInstance();
@@ -158,7 +160,8 @@ public class DexCollectionService extends Service {
     }
 
     public void setFailoverTimer() {
-        if (CollectionServiceStarter.isBTWixel(getApplicationContext())|| CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())) {
+        if (CollectionServiceStarter.isBTWixel(getApplicationContext())|| CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())
+                || CollectionServiceStarter.isWifiandBTWixel(getApplicationContext())) {
             long retry_in = (1000 * 60 * 6);
             Log.d(TAG, "setFailoverTimer: Fallover Restarting in: " + (retry_in / (60 * 1000)) + " minutes");
             Calendar calendar = Calendar.getInstance();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
@@ -25,7 +25,7 @@ public class CollectionServiceStarter {
 
     public static boolean isWifiandBTWixel(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String collection_method = prefs.getString("dex_collection_method", "WifiBlueToothWixel");
+        String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
         if(collection_method.compareTo("WifiBlueToothWixel") == 0) {
             return true;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
@@ -22,6 +22,16 @@ public class CollectionServiceStarter {
 
     private final static String TAG = CollectionServiceStarter.class.getSimpleName();
 
+
+    public static boolean isWifiandBTWixel(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        String collection_method = prefs.getString("dex_collection_method", "WifiBlueToothWixel");
+        if(collection_method.compareTo("WifiBlueToothWixel") == 0) {
+            return true;
+        }
+        return false;
+    }
+
     public static boolean isBTWixel(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
@@ -86,6 +96,17 @@ public class CollectionServiceStarter {
             stopBtWixelService();
             stopWifWixelThread();
             startBtShareService();
+        } else if (isWifiandBTWixel(context)) {
+            Log.d("DexDrip", "Starting wifi and bt wixel collector");
+            stopBtWixelService();
+            stopWifWixelThread();
+            stopBtShareService();
+            // start both
+            Log.d("DexDrip", "Starting wifi wixel collector first");
+            startWifWixelThread();
+            Log.d("DexDrip", "Starting bt wixel collector second");
+            startBtWixelService();
+            Log.d("DexDrip", "Started wifi and bt wixel collector");
         }
         if(prefs.getBoolean("broadcast_to_pebble", false)){
             startPebbleSyncService();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -293,7 +293,14 @@ public class Preferences extends PreferenceActivity {
                 collectionCategory.removePreference(runInForeground);
             }
 
-
+           if ((prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("WifiWixel") != 0)
+                   && (prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("WifiBlueToothWixel") != 0)) {
+               String receiversIpAddresses;
+               receiversIpAddresses = prefs.getString("wifi_recievers_addresses", "");
+               if (receiversIpAddresses == null || receiversIpAddresses.equals("")) {
+                   collectionCategory.removePreference(wifiRecievers);
+               }
+           }
 
 
             if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexbridgeWixel") != 0) {
@@ -343,9 +350,9 @@ public class Preferences extends PreferenceActivity {
                     // jamorham always show wifi receivers option if populated as we may switch modes dynamically
                     if((((String) newValue).compareTo("WifiWixel") != 0)
                             && (((String) newValue).compareTo("WifiBlueToothWixel") != 0)) {
-                        String recieversIpAddresses;
-                        recieversIpAddresses = prefs.getString("wifi_recievers_addresses", "");
-                        if(recieversIpAddresses == null || recieversIpAddresses.equals("") ) {
+                        String receiversIpAddresses;
+                        receiversIpAddresses = prefs.getString("wifi_recievers_addresses", "");
+                        if(receiversIpAddresses == null || receiversIpAddresses.equals("") ) {
                             collectionCategory.removePreference(wifiRecievers);
                         } else {
                             collectionCategory.addPreference(wifiRecievers);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -290,9 +290,10 @@ public class Preferences extends PreferenceActivity {
                 collectionCategory.removePreference(runInForeground);
             }
 
-            if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("WifiWixel") != 0) {
-                collectionCategory.removePreference(wifiRecievers);
-            }
+            // jamorham always show wifi receivers option as we may switch modes dynamically
+            //if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("WifiWixel") != 0) {
+            //    collectionCategory.removePreference(wifiRecievers);
+            //}
 
             if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexbridgeWixel") != 0) {
                 collectionCategory.removePreference(transmitterId);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -286,7 +286,10 @@ public class Preferences extends PreferenceActivity {
                 prefs.edit().putBoolean("calibration_notifications", false).apply();
             }
 
-            if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("BluetoothWixel") != 0 && prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexcomShare") != 0 && prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexbridgeWixel") != 0) {
+            if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("BluetoothWixel") != 0
+                    && prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("WifiBlueToothWixel") != 0
+                    && prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexcomShare") != 0
+                    && prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexbridgeWixel") != 0) {
                 collectionCategory.removePreference(runInForeground);
             }
 
@@ -339,7 +342,8 @@ public class Preferences extends PreferenceActivity {
                         collectionCategory.addPreference(runInForeground);
                     }
 
-                    if(((String) newValue).compareTo("WifiWixel") != 0) {
+                    if((((String) newValue).compareTo("WifiWixel") != 0)
+                            && (((String) newValue).compareTo("WifiBlueToothWixel") != 0)) {
                         collectionCategory.removePreference(wifiRecievers);
                     } else {
                         collectionCategory.addPreference(wifiRecievers);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -293,10 +293,8 @@ public class Preferences extends PreferenceActivity {
                 collectionCategory.removePreference(runInForeground);
             }
 
-            // jamorham always show wifi receivers option as we may switch modes dynamically
-            //if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("WifiWixel") != 0) {
-            //    collectionCategory.removePreference(wifiRecievers);
-            //}
+
+
 
             if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexbridgeWixel") != 0) {
                 collectionCategory.removePreference(transmitterId);
@@ -342,9 +340,16 @@ public class Preferences extends PreferenceActivity {
                         collectionCategory.addPreference(runInForeground);
                     }
 
+                    // jamorham always show wifi receivers option if populated as we may switch modes dynamically
                     if((((String) newValue).compareTo("WifiWixel") != 0)
                             && (((String) newValue).compareTo("WifiBlueToothWixel") != 0)) {
-                        collectionCategory.removePreference(wifiRecievers);
+                        String recieversIpAddresses;
+                        recieversIpAddresses = prefs.getString("wifi_recievers_addresses", "");
+                        if(recieversIpAddresses == null || recieversIpAddresses.equals("") ) {
+                            collectionCategory.removePreference(wifiRecievers);
+                        } else {
+                            collectionCategory.addPreference(wifiRecievers);
+                        }
                     } else {
                         collectionCategory.addPreference(wifiRecievers);
                     }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -4,6 +4,7 @@
         <item>Bluetooth Wixel</item>
         <item>xBridge Wixel</item>
         <item>Wifi Wixel</item>
+        <item>Wifi Wixel + BT Wixel</item>
         <item>DexcomShare</item>
     </string-array>
 
@@ -11,6 +12,7 @@
         <item>BluetoothWixel</item>
         <item>DexbridgeWixel</item>
         <item>WifiWixel</item>
+        <item>WifiBlueToothWixel</item>
         <item>DexcomShare</item>
     </string-array>
 


### PR DESCRIPTION
Patch allows for running both Wifi and Bluetooth modes simultaneously. Avoids having to remember to switch modes when leaving the house etc.
- Adds a new preference option for both modes and methods for starting both collection methods.
- UI fixes to prevent double display of data 
- Duplicate reading checking now ignores two readings within 100 seconds (instead of previous 10) to ensure duplicates are not possible in this mode even with potential latency delays.
