### PR TITLE
Age adjust filtered

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -1000,6 +1000,16 @@ public class BgReading extends Model {
         return age_adjusted_raw_value;
     }
 
+    public double ageAdjustedFiltered(){
+        double usedRaw = usedRaw();
+        if(usedRaw == raw_data || raw_data == 0d){
+            return filtered_data;
+        } else {
+            // adjust the filtered_data with the same factor as the age adjusted raw value
+            return filtered_data * (usedRaw/raw_data);
+        }
+    }
+
     // the input of this function is a string. each char can be g(=good) or b(=bad) or s(=skip, point unmissed).
     static List<BgReading> createlatestTest(String input, Long now) {
         Random randomGenerator = new Random();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -273,7 +273,7 @@ public class NightscoutUploader {
             json.put("sgv", (int)record.calculated_value);
             json.put("direction", record.slopeName());
             json.put("type", "sgv");
-            json.put("filtered", record.filtered_data * 1000);
+            json.put("filtered", record.ageAdjustedFiltered() * 1000);
             json.put("unfiltered", record.usedRaw() * 1000);
             json.put("rssi", 100);
             json.put("noise", record.noiseValue());
@@ -374,7 +374,7 @@ public class NightscoutUploader {
                             testData.put("sgv", Math.round(record.calculated_value));
                             testData.put("direction", record.slopeName());
                             testData.put("type", "sgv");
-                            testData.put("filtered", record.filtered_data * 1000);
+                            testData.put("filtered", record.ageAdjustedFiltered() * 1000);
                             testData.put("unfiltered", record.usedRaw() * 1000);
                             testData.put("rssi", 100);
                             testData.put("noise", record.noiseValue());


### PR DESCRIPTION
I hope this solves the problem with NS showing "raw" data with xDrip (maybe not yet xBridge)
(Hope as in: I cannot test it, but it seems very very likely to me that this is the problem.)

Thanks @jstevensog for taking over from here :)

Nightscout adjusts the raw datum with a ratio it calculates from the sgv and the filtered datum (the datum the sgv usually is calculated with). As xDrip calculates it with an age adjusted value but still uploads a non age adjusted value as filtered datum, the ration may become not 1 where it should be.
https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/plugins/rawbg.js#L59

xBridge:
As the filtered value for xBridge is acutally set and not a duplicate of raw_data, I just can think of two solutions:

a) Upload "0" as filtered - then no factor will be calculated in NS
b) Upload "age_adjusted_raw" as "filtered".
