### PR TITLE
Simplify network debug output by logging only a one line error...

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
@@ -306,10 +306,10 @@ public class WixelReader  extends Thread {
             MySocket.close();
             return trd_list;
         }catch(SocketTimeoutException s) {
-            Log.e(TAG, "Socket timed out! ", s);
+            Log.e(TAG, "Socket timed out! "+ s.toString());
         }
         catch(IOException e) {
-            Log.e(TAG, "cought IOException! ", e);
+            Log.e(TAG, "cought IOException! "+ e.toString());
         }
         return trd_list;
     }


### PR DESCRIPTION
Simplify debug output by logging only a one line error instead of a multi-line call trace when a network connection times out or otherwise fails.

At the moment when running wifi wixels, if these connections fail, like when not connected to wifi etc, a multi-line call trace is logged. This seems excessive as a network timeout or other error is not something requiring the code flow to be debugged.

This patch reduces these to a single line message which just gives the status of what happened, for example "network unreachable"
