### PR TITLE
Altered RetryTime time for xBridge.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/DexCollectionService.java
@@ -149,7 +149,12 @@ public class DexCollectionService extends Service {
 
     public void setRetryTimer() {
         if (CollectionServiceStarter.isBTWixel(getApplicationContext()) || CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())) {
-            long retry_in = (1000 * 65);
+            long retry_in;
+            if(CollectionServiceStarter.isDexbridgeWixel(getApplicationContext())) {
+                retry_in = (1000 * 25);
+            } else {
+                retry_in = (1000*65);
+            }
             Log.d(TAG, "setRetryTimer: Restarting in: " + (retry_in/1000)  + " seconds");
             Calendar calendar = Calendar.getInstance();
             AlarmManager alarm = (AlarmManager) getSystemService(ALARM_SERVICE);


### PR DESCRIPTION
I found the 65 second retry time was too long for xBridge at times.  Reducing it to 25 seconds has given a good boost to performance.  I believe that Android often gets too busy to allow the retry timer to be reliable, and sometimes xDrip does not re-establish the connection to a newly woken xBridge in time to get the data packet.  This change has proven this thought to be somewhat correct.

I decided not to make it shorter than this to keep the logs from filling up with messages about it.
