### PR TITLE
Enabled high precision Delta String with units.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/PebbleSync.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/PebbleSync.java
@@ -135,7 +135,7 @@ public class PebbleSync extends Service {
     }
 
     public String bgDelta() {
-        return new BgGraphBuilder(mContext).unitizedDeltaString(false, false);
+        return new BgGraphBuilder(mContext).unitizedDeltaString(true, true);
     }
 
     public String phoneBattery() {


### PR DESCRIPTION
NOTE: DO NOT MERGE THIS UNTIL A NEW WATCH FACE IS PUSHED!!!!

This version ensures the xDrip Pebble watch face display exactly the same Delta strings as the all other xDrip displays (assuming they stay as high precision).  It has the added benefit of displaying the correct fraction/decimal separator for a person's locale.

Merging this into xDrip Beta or Release will break the watch face for users.  The current watch face is expecting only a numerical string with 2 decimal places, and  no units.
I have created a "dumber" watch face that will need to be pushed to the Pebble Store before this is merged and put into general circulation.  This watch face simply accepts the full unitized delta string with units and displays it as is.  No fancy conversion to Integer and determining if it has a decimal point in it to then add the units.  A much better way to do things.  Sorry it took me so long to get to this.

A person using the a version of xDrip that does not have this pull request merged, and running the "dumber" watch face will get all the info, only the units will be missing from Delta reading.  So it is feasible to inform users through Facebook that they may lose the units until they install the next xDrip beta/release, then push the watch face up before the xDrip version is released.

That would make an easy transition to this.
Happy to discuss.
