### PR TITLE
Only show two decimal places on mmol/l when delta is below 0.1 mmol

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -384,7 +384,8 @@ public class BgGraphBuilder {
             return delta_sign + df.format(unitized(value)) +  (showUnit?" mg/dl":"");
         } else {
 
-            if(highGranularity){
+            // only show 2 decimal places on mmol/l delta when less than 0.1 mmol/l
+            if(highGranularity && (Math.abs(value)<(Constants.MMOLL_TO_MGDL*0.1))){
                 df.setMaximumFractionDigits(2);
             } else {
                 df.setMaximumFractionDigits(1);


### PR DESCRIPTION
BG values in mmol/l are normally only expressed to a single decimal place by glucose meters etc. The only time I feel two decimal places would be useful is when it would otherwise display 0.0 and then the additional accuracy could be useful to see exactly how "flat" a slope really is.

Prior to this patch, displaying two decimal places I think reduces the speed at which someone can read the display as they have to mentally examine the extra digit and reduces the "at a glance" value of the delta display. 

Should I be submitting patches to master or the beta-2 branch? I am not clear which is the most appropriate channel.
