### PR TITLE
Mongo REST upload

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
@@ -226,8 +226,8 @@ public class WixelReader  extends Thread {
             if (host.startsWith("mongodb://")) {
             	tmpList = ReadFromMongo(host ,numberOfRecords);
             } else if (host.startsWith("mongodb-rest")) {
-                MongoLabRest mongoLabRest = MongoLabRest.testInstance(null);
-                tmpList = mongoLabRest.ReadFromMongo(ctx, "SnirData");
+                MongoLabRest mongoLabRest = MongoLabRest.testInstance(ctx);
+                tmpList = mongoLabRest.readFromMongo(ctx, "SnirData");
             }
             else {
             	tmpList = ReadHost(host, numberOfRecords);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
@@ -14,14 +14,15 @@ import java.util.List;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import com.eveningoutpost.dexdrip.Models.UserError.Log;
 
+import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.utils.BgToSpeech;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.eveningoutpost.dexdrip.Sensor;
 import com.eveningoutpost.dexdrip.Models.BgReading;
 import com.eveningoutpost.dexdrip.Models.TransmitterData;
+import com.eveningoutpost.dexdrip.UtilityModels.MongoLabRest;
 
 public class WixelReader  extends Thread {
 
@@ -209,7 +210,7 @@ public class WixelReader  extends Thread {
     }
 
     // format of string is ip1:port1,ip2:port2;
-    public static TransmitterRawData[] Read(String hostsNames, int numberOfRecords)
+    public static TransmitterRawData[] Read(Context ctx, String hostsNames, int numberOfRecords)
     {
         String []hosts = hostsNames.split(",");
         if(hosts.length == 0) {
@@ -224,7 +225,11 @@ public class WixelReader  extends Thread {
             List<TransmitterRawData> tmpList;
             if (host.startsWith("mongodb://")) {
             	tmpList = ReadFromMongo(host ,numberOfRecords);
-            } else {
+            } else if (host.startsWith("mongodb-rest")) {
+                MongoLabRest mongoLabRest = MongoLabRest.testInstance(null);
+                tmpList = mongoLabRest.ReadFromMongo(ctx, "SnirData");
+            }
+            else {
             	tmpList = ReadHost(host, numberOfRecords);
             }
             if(tmpList != null && tmpList.size() > 0) {
@@ -310,10 +315,10 @@ public class WixelReader  extends Thread {
             MySocket.close();
             return trd_list;
         }catch(SocketTimeoutException s) {
-            Log.e(TAG, "Socket timed out! ", s);
+            Log.e(TAG, "Socket timed out! "+ s.toString());
         }
         catch(IOException e) {
-            Log.e(TAG, "cought IOException! ", e);
+            Log.e(TAG, "cought IOException! "+ e.toString());
         }
         return trd_list;
     }
@@ -331,7 +336,7 @@ public class WixelReader  extends Thread {
                 if(WixelReader.IsConfigured(mContext)) {
                     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
                     String recieversIpAddresses = prefs.getString("wifi_recievers_addresses", "");
-	        		LastReadingArr = Read(recieversIpAddresses ,1);
+	        		LastReadingArr = Read(mContext, recieversIpAddresses ,1);
                 }
 	        	if (LastReadingArr != null  && LastReadingArr.length  > 0) {
 	        		// Last in the array is the most updated reading we have.

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CollectionServiceStarter.java
@@ -98,7 +98,7 @@ public class CollectionServiceStarter {
             String filePath = Environment.getExternalStorageDirectory() + "/xdriplogcat.txt";
             try {
                 String[] cmd = {"/system/bin/sh", "-c", "ps | grep logcat  || logcat -f " + filePath +
-                        " -v threadtime AlertPlayer:V com.eveningoutpost.dexdrip.Services.WixelReader:V *:E "};
+                        " -v threadtime AlertPlayer:V com.eveningoutpost.dexdrip.Services.WixelReader:V MongoLabRest:V *:E "};
                 Runtime.getRuntime().exec(cmd);
             } catch (IOException e2) {
                 Log.e(TAG, "running logcat failed, is the device rooted?", e2);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
@@ -78,7 +78,7 @@ public class MongoLabRest {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
         String dbName = prefs.getString("cloud_storage_mongodb_rest_database", "nightscout");
         String apiKey = prefs.getString("cloud_storage_mongodb_rest_key", "");
-        
+
         return new MongoLabRest(dbName, apiKey, ctx);
     }
 
@@ -129,7 +129,7 @@ public class MongoLabRest {
         if (!populateJasonMBG(json, cal)) {
             return false;
         }
-        
+
         String dsCollectionName = prefs.getString("cloud_storage_mongodb_collection", "entries");
         return sendToMongo(dsCollectionName, json);
     }
@@ -187,7 +187,7 @@ public class MongoLabRest {
             Log.e(TAG, "sendToMongo Exception: ", e);
             return false;
         }
-        
+
         return success;
     }
 
@@ -230,8 +230,11 @@ public class MongoLabRest {
 
 
     private boolean populateJasonDeviceStatus(JSONObject json, int batteryLevel) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        format.setTimeZone(TimeZone.getDefault());
         try {
             json.put("uploaderBattery", batteryLevel);
+            json.put("created_at", format.format(System.currentTimeMillis()));
             return true;
         } catch (JSONException e) {
             return false;
@@ -261,31 +264,31 @@ public class MongoLabRest {
             return false;
         }
     }
-    
-    
-    
+
+
+
     public List<TransmitterRawData> fromJson(Context ctx, String data) {
-        
+
         Gson gson = new Gson();
         Type listType = new TypeToken<List<TransmitterRawData>>(){}.getType();
-        
-        List<TransmitterRawData> trdList = gson.fromJson(data, listType); 
-        
+
+        List<TransmitterRawData> trdList = gson.fromJson(data, listType);
+
         //Toast.makeText(ctx, "objects read " + asd.size(), Toast.LENGTH_LONG).show();
         Log.e(TAG,  "objects read " + trdList.size());
         return trdList;
-        
-        
+
+
     }
-    
-    
+
+
     // This function is based on    
     //http://www.javacodegeeks.com/2012/09/simple-rest-client-in-java.html
-    
+
     // To encode a query use:
     // web encoder: http://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_encodeuricomponent 
     // after that replace 3d with "="
-    
+
     public List<TransmitterRawData> readFromMongo(Context ctx, String collectionName) {
         Log.e(TAG, "starting readFromMongo");
 
@@ -300,7 +303,7 @@ public class MongoLabRest {
         HttpParams params = new BasicHttpParams();
         HttpConnectionParams.setSoTimeout(params, SOCKET_TIMEOUT);
         HttpConnectionParams.setConnectionTimeout(params, CONNECTION_TIMEOUT);
-        
+
         HttpClient httpClient = new DefaultHttpClient(params);
         try {
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
@@ -49,14 +49,7 @@ import java.util.TimeZone;
  */
 public class MongoLabRest {
 
-    //*********************************************************************
-    // FOR TESTING:
-    // Should be read from settings/preferences in final version
-    private static final String DATABASE = "mydb";
-    private static final String API_KEY = "D2a6iaurh-oihXrraOquZSySx9QnT_Gs";
     // How to get an API-Key: http://docs.mongolab.com/data-api/#authentication
-    // TODO: DELETE APIKEY! (provoke syntax error on purpose -> error while building if not set again)
-    //*********************************************************************
 
     public static final String BASE_URL = "https://api.mongolab.com/api/1/databases/";
     public static final String TAG = "MongoLabRest";

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.TimeZone;
 
 /**
- * Created by adrian on 24/09/15.
+ * Created by adrian on 24/09/15.*
  */
 public class MongoLabRest {
 
@@ -139,16 +139,13 @@ public class MongoLabRest {
             HttpParams params = new BasicHttpParams();
             HttpConnectionParams.setSoTimeout(params, SOCKET_TIMEOUT);
             HttpConnectionParams.setConnectionTimeout(params, CONNECTION_TIMEOUT);
-
             DefaultHttpClient httpclient = new DefaultHttpClient(params);
-
             HttpPost post = new HttpPost(url);
             String jsonString = json.toString();
             StringEntity se = new StringEntity(jsonString);
             post.setEntity(se);
             //post.setHeader("Accept", "application/json");
             post.setHeader("Content-type", "application/json");
-
             ResponseHandler responseHandler = new BasicResponseHandler();
             httpclient.execute(post, responseHandler);
         } catch (ClientProtocolException e) {
@@ -175,7 +172,7 @@ public class MongoLabRest {
             json.put("sgv", (int) bgReading.calculated_value);
             json.put("direction", bgReading.slopeName());
             json.put("type", "sgv");
-            json.put("filtered", bgReading.ageAdjustedFiltered() * 1000);
+            json.put("filtered", bgReading.filtered_data * 1000);
             json.put("unfiltered", bgReading.usedRaw() * 1000);
             json.put("rssi", 100);
             json.put("noise", bgReading.noiseValue());

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
@@ -1,0 +1,237 @@
+package com.eveningoutpost.dexdrip.UtilityModels;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+
+import com.eveningoutpost.dexdrip.Models.BgReading;
+import com.eveningoutpost.dexdrip.Models.Calibration;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Created by adrian on 24/09/15.
+ */
+public class MongoLabRest {
+
+    //*********************************************************************
+    // FOR TESTING:
+    // Should be read from settings/preferences in final version
+    private static final String DATABASE = "mydb";
+    private static final String API_KEY = ;
+    // How to get an API-Key: http://docs.mongolab.com/data-api/#authentication
+    // TODO: DELETE APIKEY! (provoke syntax error on purpose -> error while building if not set again)
+    //*********************************************************************
+
+    public static final String BASE_URL = "https://api.mongolab.com/api/1/databases/";
+    public static final String TAG = "MongoLabRest";
+    private static final String DEFAULT_BG_COLLECTION = "entries";
+    private static final String DEFAULT_METER_COLLECTION = "entries";
+    private static final String DEFAULT_CALIBRATION_COLLECTION = "entries";
+    private static final String DEFAULT_DEVICESTATUS_COLLECTION = "devicestatus";
+    private static final String UPSERT = "&u=true";
+    private static final int SOCKET_TIMEOUT = 60000;
+    private static final int CONNECTION_TIMEOUT = 30000;
+    private String apiKey;
+    private String dbName;
+    private SharedPreferences prefs;
+
+
+    public MongoLabRest(String dbName, String apiKey, Context mContext) {
+        this.dbName = dbName;
+        this.apiKey = apiKey;
+        prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+    }
+
+    public static MongoLabRest testInstance(Context ctx) {
+        return new MongoLabRest(DATABASE, API_KEY, ctx);
+    }
+
+    public boolean sendSGVToMongo(List<BgReading> bgReadings) {
+        for (BgReading bgReading : bgReadings) {
+            if (!sendSGVToMongo(bgReading)) {
+                return false;
+            } else {
+                Log.v(TAG, "sendSGVToMongo-success");
+            }
+        }
+        return true;
+    }
+
+    public boolean sendMBGToMongo(List<Calibration> cals) {
+        for (Calibration cal : cals) {
+            if (!sendMBGToMongo(cal)) {
+                return false;
+            } else {
+                Log.v(TAG, "sendMBGToMongo-success");
+            }
+        }
+        return true;
+    }
+
+    public boolean sendCALToMongo(List<Calibration> cals) {
+        for (Calibration cal : cals) {
+            if (!sendCALToMongo(cal)) {
+                return false;
+            } else {
+                Log.v(TAG, "sendCALToMongo-success");
+            }
+        }
+        return true;
+    }
+
+    public boolean sendSGVToMongo(BgReading bgReading) {
+        JSONObject json = new JSONObject();
+        if (!populateJasonBG(json, bgReading)) {
+            return false;
+        }
+        return sendToMongo(DEFAULT_BG_COLLECTION, json);
+    }
+
+    public boolean sendMBGToMongo(Calibration cal) {
+        JSONObject json = new JSONObject();
+        if (!populateJasonMBG(json, cal)) {
+            return false;
+        }
+        return sendToMongo(DEFAULT_METER_COLLECTION, json);
+    }
+
+    public boolean sendCALToMongo(Calibration cal) {
+        JSONObject json = new JSONObject();
+        if (!populateJasonCAL(json, cal)) {
+            return false;
+        }
+        return sendToMongo(DEFAULT_CALIBRATION_COLLECTION, json);
+    }
+
+    public boolean sendDeviceStatusToMongo(int batteryLevel){
+        JSONObject json = new JSONObject();
+        if (!populateJasonDeviceStatus(json, batteryLevel)) {
+            return false;
+        }
+        return sendToMongo(DEFAULT_DEVICESTATUS_COLLECTION, json);
+    }
+
+
+    public boolean sendToMongo(String collectionName, JSONObject json) {
+        Log.d(TAG, "sendToMongo");
+        String url = BASE_URL + dbName + "/collections/" + collectionName + "?apiKey=" + apiKey + UPSERT;
+
+
+        try {
+            HttpParams params = new BasicHttpParams();
+            HttpConnectionParams.setSoTimeout(params, SOCKET_TIMEOUT);
+            HttpConnectionParams.setConnectionTimeout(params, CONNECTION_TIMEOUT);
+
+            DefaultHttpClient httpclient = new DefaultHttpClient(params);
+
+            HttpPost post = new HttpPost(url);
+            String jsonString = json.toString();
+            StringEntity se = new StringEntity(jsonString);
+            post.setEntity(se);
+            //post.setHeader("Accept", "application/json");
+            post.setHeader("Content-type", "application/json");
+
+            ResponseHandler responseHandler = new BasicResponseHandler();
+            httpclient.execute(post, responseHandler);
+        } catch (ClientProtocolException e) {
+            Log.e(TAG, "failed: ", e);
+            return false;
+        } catch (UnsupportedEncodingException e) {
+            Log.e(TAG, "failed: ", e);
+            return false;
+        } catch (IOException e) {
+            Log.e(TAG, "failed: ", e);
+            return false;
+        }
+        return true;
+    }
+
+
+    private boolean populateJasonBG(JSONObject json, BgReading bgReading) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        format.setTimeZone(TimeZone.getDefault());
+        try {
+            json.put("device", "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel"));
+            json.put("date", bgReading.timestamp);
+            json.put("dateString", format.format(bgReading.timestamp));
+            json.put("sgv", (int) bgReading.calculated_value);
+            json.put("direction", bgReading.slopeName());
+            json.put("type", "sgv");
+            json.put("filtered", bgReading.ageAdjustedFiltered() * 1000);
+            json.put("unfiltered", bgReading.usedRaw() * 1000);
+            json.put("rssi", 100);
+            json.put("noise", bgReading.noiseValue());
+            return true;
+        } catch (JSONException e) {
+            return false;
+        }
+    }
+
+
+    private boolean populateJasonMBG(JSONObject json, Calibration record) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        format.setTimeZone(TimeZone.getDefault());
+        try {
+            json.put("device", "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel"));
+            json.put("type", "mbg");
+            json.put("date", record.timestamp);
+            json.put("dateString", format.format(record.timestamp));
+            json.put("mbg", record.bg);
+            return true;
+        } catch (JSONException e) {
+            return false;
+        }
+    }
+
+
+    private boolean populateJasonDeviceStatus(JSONObject json, int batteryLevel) {
+        try {
+            json.put("uploaderBattery", batteryLevel);
+            return true;
+        } catch (JSONException e) {
+            return false;
+        }
+    }
+
+
+    private boolean populateJasonCAL(JSONObject json, Calibration record) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        format.setTimeZone(TimeZone.getDefault());
+        try {
+            json.put("device", "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel"));
+            json.put("type", "cal");
+            json.put("date", record.timestamp);
+            json.put("dateString", format.format(record.timestamp));
+            if (record.check_in) {
+                json.put("slope", (long) (record.first_slope));
+                json.put("intercept", (long) ((record.first_intercept)));
+                json.put("scale", record.first_scale);
+            } else {
+                json.put("slope", (long) (record.slope * 1000));
+                json.put("intercept", (long) ((record.intercept * -1000) / (record.slope * 1000)));
+                json.put("scale", 1);
+            }
+            return true;
+        } catch (JSONException e) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
@@ -130,7 +130,7 @@ public class MongoLabRest {
             return false;
         }
         
-        String dsCollectionName = prefs.getString("cloud_storage_mongodb_device_status_collection", "entries");
+        String dsCollectionName = prefs.getString("cloud_storage_mongodb_collection", "entries");
         return sendToMongo(dsCollectionName, json);
     }
 
@@ -139,7 +139,7 @@ public class MongoLabRest {
         if (!populateJasonCAL(json, cal)) {
             return false;
         }
-        String dsCollectionName = prefs.getString("cloud_storage_mongodb_device_status_collection", "entries");
+        String dsCollectionName = prefs.getString("cloud_storage_mongodb_collection", "entries");
         return sendToMongo(dsCollectionName, json);
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
@@ -120,7 +120,7 @@ public class MongoLabRest {
         if (!populateJasonBG(json, bgReading)) {
             return false;
         }
-        String collectionName = prefs.getString("cloud_storage_mongodb_collection", null);
+        String collectionName = prefs.getString("cloud_storage_mongodb_collection", "entries");
         return sendToMongo(collectionName, json);
     }
 
@@ -130,7 +130,7 @@ public class MongoLabRest {
             return false;
         }
         
-        String dsCollectionName = prefs.getString("cloud_storage_mongodb_device_status_collection", "devicestatus");
+        String dsCollectionName = prefs.getString("cloud_storage_mongodb_device_status_collection", "entries");
         return sendToMongo(dsCollectionName, json);
     }
 
@@ -139,7 +139,7 @@ public class MongoLabRest {
         if (!populateJasonCAL(json, cal)) {
             return false;
         }
-        String dsCollectionName = prefs.getString("cloud_storage_mongodb_device_status_collection", "devicestatus");
+        String dsCollectionName = prefs.getString("cloud_storage_mongodb_device_status_collection", "entries");
         return sendToMongo(dsCollectionName, json);
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoLabRest.java
@@ -171,7 +171,7 @@ public class MongoLabRest {
             post.setHeader("Content-type", "application/json");
             HttpResponse response = httpclient.execute(post);
             Log.d(TAG, "Send returned code is " + response.getStatusLine().getStatusCode());
-            if( response.getStatusLine().getStatusCode() == 200) {
+            if( response.getStatusLine().getStatusCode() == 200 || response.getStatusLine().getStatusCode() == 201) {
                 success  = true;
             }
         } catch (ClientProtocolException e) {
@@ -287,6 +287,7 @@ public class MongoLabRest {
     // after that replace 3d with "="
     
     public List<TransmitterRawData> readFromMongo(Context ctx, String collectionName) {
+        Log.e(TAG, "starting readFromMongo");
 
         List<TransmitterRawData> trdList = null;
 
@@ -296,8 +297,11 @@ public class MongoLabRest {
 
         String url = BASE_URL + dbName + "/collections/" + collectionName +"?" + exists + "&"  + sort+ "&l=1&apiKey=" + apiKey;
 
-
-        HttpClient httpClient = new DefaultHttpClient();
+        HttpParams params = new BasicHttpParams();
+        HttpConnectionParams.setSoTimeout(params, SOCKET_TIMEOUT);
+        HttpConnectionParams.setConnectionTimeout(params, CONNECTION_TIMEOUT);
+        
+        HttpClient httpClient = new DefaultHttpClient(params);
         try {
 
             HttpGet httpGetRequest = new HttpGet(url);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -86,8 +86,19 @@ public class NightscoutUploader {
 
             if (enableMongoUpload) {
                 double start = new Date().getTime();
-                mongoStatus = doMongoUpload(prefs, glucoseDataSets, meterRecords, calRecords);
-                Log.i(TAG, String.format("Finished upload of %s record using a Mongo in %s ms", glucoseDataSets.size() + meterRecords.size(), System.currentTimeMillis() - start));
+
+                MongoLabRest mongoLabRest = MongoLabRest.testInstance(mContext);
+                mongoStatus =
+                        mongoLabRest.sendSGVToMongo(glucoseDataSets) &&
+                                mongoLabRest.sendMBGToMongo(meterRecords) &&
+                                mongoLabRest.sendCALToMongo(calRecords)&&
+                                mongoLabRest.sendDeviceStatusToMongo(getBatteryLevel());
+
+                if (mongoStatus){
+                    Log.i(TAG, String.format("Finished upload of %s record using a Mongo in %s ms", glucoseDataSets.size() + meterRecords.size(), System.currentTimeMillis() - start));
+                } else {
+                    Log.i(TAG, String.format("Upload to mongolab failed."));
+                }
             }
 
                 return apiStatus || mongoStatus;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -258,6 +258,8 @@ public class Preferences extends PreferenceActivity {
             setupBarcodeShareScanner();
             bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_uri"));
             bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_collection"));
+            bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_rest_key"));
+            bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_rest_database"));
             bindPreferenceSummaryToValue(findPreference("cloud_storage_mongodb_device_status_collection"));
             bindPreferenceSummaryToValue(findPreference("cloud_storage_api_base"));
 

--- a/app/src/main/res/xml/pref_data_sync.xml
+++ b/app/src/main/res/xml/pref_data_sync.xml
@@ -20,14 +20,34 @@
                 android:title="Enable Nightscout Mongo DB sync"
                 android:defaultValue="false" />
             <EditTextPreference
+                android:enabled="false"
                 android:dependency="cloud_storage_mongodb_enable"
-                android:title="Mongo DB Uri"
+                android:title="Mongo DB Uri - please configure rest api below. see ?????"
                 android:key="cloud_storage_mongodb_uri"
                 android:dialogTitle="@string/pref_dialog_mongodb_uri"
                 android:dialogMessage="@string/pref_message_mongodb_uri"
                 android:defaultValue="@string/pref_default_mongodb_uri"
                 android:inputType="textUri">
             </EditTextPreference>
+            
+            <EditTextPreference
+                android:dependency="cloud_storage_mongodb_enable"
+                android:title="key for mongolab rest api"
+                android:key="cloud_storage_mongodb_rest_key"
+                android:dialogTitle="@string/pref_dialog_mongodb_collection"
+                android:dialogMessage="This is the key that identifies your rest api"
+                android:defaultValue="D2a6iaurh-oihXrraOquZSySx9QnT_G">
+            </EditTextPreference>
+            
+            <EditTextPreference
+                android:dependency="cloud_storage_mongodb_enable"
+                android:title="database name"
+                android:key="cloud_storage_mongodb_rest_database"
+                android:dialogTitle="Enter key name"
+                android:dialogMessage="@string/pref_message_mongodb_collection"
+                android:defaultValue="nightscout">
+            </EditTextPreference>
+            
             <EditTextPreference
                 android:dependency="cloud_storage_mongodb_enable"
                 android:title="@string/pref_title_mongodb_collection"


### PR DESCRIPTION
TESTING - please do NOT merge

With the mongo 3 update we will lose the ability to directly upload to mongolab as the new java-driver does not run on Android.

As some people (including me) would still prefer direct Mongolab upload to the upload via Nightscout (not using NS, using Mongolab just to mirror data or to view on Garmin watch, ...), I wrote a first version of a REST-Uploader for MongoLab. The Rest-API upload is used by the chrome uploader as well and seems to be pretty stable.
We also may use this as a starting point to rewrite the NS-Rest-Upload, as they are pretty similar (code borrowed from current Rest-Upload).

So far it worked for me and takes 19930.0 ms to upload 32 records.

For testing:
- enable mongolab in settings (url does not matter)
- in class com.eveningoutpost.dexdrip.UtilityModels.MongoLabRest:
  - enter your database name as string constant DATABASE
  - enter your apiKey as string constant API_KEY (http://docs.mongolab.com/data-api/#authentication)

It would be great if you could test that! If it works, we can move the db-name and API-Secret to the settings and clean the old code from NightscoutUploader.
(@tzachi-dar - this is a newer version than I mailed you.)
