### PR TITLE
Force the use of the dot when speaking the bg reading in mmol/l format.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/BgToSpeech.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/BgToSpeech.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import com.eveningoutpost.dexdrip.UtilityModels.Constants;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 /**
@@ -118,6 +119,7 @@ public class BgToSpeech {
                 df.setMaximumFractionDigits(0);
                 text =  df.format(value);
             } else {
+                df = new DecimalFormat("##.#", new DecimalFormatSymbols(Locale.US));
                 df.setMaximumFractionDigits(1);
                 df.setMinimumFractionDigits(1);
                 text =  df.format(value* Constants.MGDL_TO_MMOLL);


### PR DESCRIPTION
On my Nexus 7 TTS works well, it shows and speaks a dot (5.4) instead of a comma (5,4). On my S5 mini it shows a comma (5,4) and the TTS fails to speak the comma. It says "five four" instead of "five point four". I guess it's got something to do with the locale settings on the devices. Anyway, I don't think the comma will ever be spoken by the TTS.

In this PR I simply forced the locale to be US such that the text to be spoken is always using a dot in order to make sure I hear "five point four" instead of "five four". 

It might also be worthwhile changing the display of "5,4" to "5.4". Maybe other people like seeing a comma instead of a dot, I prefer a dot.
