### PR TITLE
Split disable alerts all into disable low and high

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -296,8 +296,8 @@ public class Home extends ActivityWithMenu {
         }
 
         final long now = System.currentTimeMillis();
-        if (Sensor.currentSensor().started_at + 60000 * 5 * 2 >= now) {
-            double waitTime = (Sensor.currentSensor().started_at + 60000 * 5 * 2 - now) / 60000.0;
+        if (Sensor.currentSensor().started_at + 60000 * 60 * 2 >= now) {
+            double waitTime = (Sensor.currentSensor().started_at + 60000 * 60 * 2 - now) / 60000.0;
             notificationText.setText("Please wait while sensor warms up! (" + String.format("%.2f", waitTime) + " minutes)");
             return;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -288,8 +288,8 @@ public class Home extends ActivityWithMenu {
         }
 
         final long now = System.currentTimeMillis();
-        if (Sensor.currentSensor().started_at + 60000 * 60 * 2 >= now) {
-            double waitTime = (Sensor.currentSensor().started_at + 60000 * 60 * 2 - now) / 60000.0;
+        if (Sensor.currentSensor().started_at + 60000 * 5 * 2 >= now) {
+            double waitTime = (Sensor.currentSensor().started_at + 60000 * 5 * 2 - now) / 60000.0;
             notificationText.setText("Please wait while sensor warms up! (" + String.format("%.2f", waitTime) + " minutes)");
             return;
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -767,10 +767,6 @@ public class BgReading extends Model implements ShareUploadableBg{
             Log.i("NOTIFICATIONS", "checkForRisingAllert: Notifications are currently disabled!!");
             return;
         }
-        if(prefs.getLong("high_alerts_disabled_until", 0) > new Date().getTime()){
-            Log.i("NOTIFICATIONS", "checkForRisingAllert: High alerts are currently disabled!!");
-            return;
-        }
 
         if(IsUnclearTime(context)) {
             Log.d(TAG_ALERT, "checkForRisingAllert we are in an clear time, returning without doing anything");
@@ -803,10 +799,6 @@ public class BgReading extends Model implements ShareUploadableBg{
         }
         if(prefs.getLong("alerts_disabled_until", 0) > new Date().getTime()){
             Log.d("NOTIFICATIONS", "checkForDropAllert: Notifications are currently disabled!!");
-            return;
-        }
-        if(prefs.getLong("low_alerts_disabled_until", 0) > new Date().getTime()){
-            Log.d("NOTIFICATIONS", "checkForDropAllert: Low alerts are currently disabled!!");
             return;
         }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -251,7 +251,7 @@ public class Notifications extends IntentService {
         if (calibration_notifications) {
             if (bgReadings.size() >= 3) {
                 if (calibrations.size() == 0 && (new Date().getTime() - bgReadings.get(2).timestamp <= (60000 * 30)) && sensor != null) {
-                    if ((sensor.started_at + (60000 * 60 * 2)) < new Date().getTime()) {
+                    if ((sensor.started_at + (60000 * 5 * 2)) < new Date().getTime()) {
                         doubleCalibrationRequest();
                     } else { clearDoubleCalibrationRequest(); }
                 } else { clearDoubleCalibrationRequest(); }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -251,7 +251,7 @@ public class Notifications extends IntentService {
         if (calibration_notifications) {
             if (bgReadings.size() >= 3) {
                 if (calibrations.size() == 0 && (new Date().getTime() - bgReadings.get(2).timestamp <= (60000 * 30)) && sensor != null) {
-                    if ((sensor.started_at + (60000 * 5 * 2)) < new Date().getTime()) {
+                    if ((sensor.started_at + (60000 * 60 * 2)) < new Date().getTime()) {
                         doubleCalibrationRequest();
                     } else { clearDoubleCalibrationRequest(); }
                 } else { clearDoubleCalibrationRequest(); }


### PR DESCRIPTION
Snooze Screen : split disable alerts into 'disable all', 'disable low' and 'disable high' - also delete active bg alerts that fall within range of disabled alerts.
- The screen now has three buttons on the bottom : one to just disable low bg alerts, one for the high bg alerts and one for all alerts
- Disable and re-enable all alerts works as before, when disabling all, the two other buttons disappear. 
- When re-enabling all, the two others buttons re-appear in the screen, and also bg low and high alerts will be re-enabled, whatever the status was before
- If high alert exists, and disable high or all is done, then the existing high alert will be deleted.
- If low alert exists, and disable low or all is done, then the existing low alert will be deleted
- in the home screen, the warning messages is adapted according to the alerts being disabled : "All alerts, high alerts or low alerts"

(ignore the commit i did related to chaning warm up period of sensor - this I do during testing so I don't need to wait 2 hours)
