### PR TITLE
Don't reraise snoozed activebgalert if more than 3 missed readings

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -165,7 +165,7 @@ public class Notifications extends IntentService {
             if (activeBgAlert.uuid.equals(newAlert.uuid)) {
                 // This is the same alert. Might need to play again...
 
-                //if more than two readings missed, don't replay
+                //if more than three readings missed, don't replay
                 if ((new Date().getTime()) - (60000 * 17) - BgReading.lastNoSenssor().timestamp > 0){
                     Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than two readings missed :  " + newAlert.name);
                     return;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -164,6 +164,13 @@ public class Notifications extends IntentService {
 
             if (activeBgAlert.uuid.equals(newAlert.uuid)) {
                 // This is the same alert. Might need to play again...
+
+                //if more than two readings missed, don't replay
+                if ((new Date().getTime()) - (60000 * 11) - BgReading.lastNoSenssor().timestamp > 0){
+                    Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than two readings missed :  " + newAlert.name);
+                    return;
+                }
+
                 Log.d(TAG, "FileBasedNotifications we have found an active alert, checking if we need to play it " + newAlert.name);
                 boolean trendingToAlertEnd = trendingToAlertEnd(context, false, newAlert);
                 AlertPlayer.getPlayer().ClockTick(context, trendingToAlertEnd, EditAlertActivity.unitsConvert2Disp(doMgdl, bgReading.calculated_value));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -166,7 +166,7 @@ public class Notifications extends IntentService {
                 // This is the same alert. Might need to play again...
 
                 //if more than two readings missed, don't replay
-                if ((new Date().getTime()) - (60000 * 11) - BgReading.lastNoSenssor().timestamp > 0){
+                if ((new Date().getTime()) - (60000 * 17) - BgReading.lastNoSenssor().timestamp > 0){
                     Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than two readings missed :  " + newAlert.name);
                     return;
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -166,7 +166,7 @@ public class Notifications extends IntentService {
                 // This is the same alert. Might need to play again...
 
                 //disable alert on stale data
-                if(prefs.getBoolean("disable_alerts_stale_data", true)) {
+                if(prefs.getBoolean("disable_alerts_stale_data", false)) {
                     int minutes = Integer.parseInt(prefs.getString("disable_alerts_stale_data_minutes", "15")) + 2;
                     if ((new Date().getTime()) - (60000 * minutes) - BgReading.lastNoSenssor().timestamp > 0) {
                         Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than three readings missed :  " + newAlert.name);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -167,7 +167,7 @@ public class Notifications extends IntentService {
 
                 //if more than three readings missed, don't replay
                 if ((new Date().getTime()) - (60000 * 17) - BgReading.lastNoSenssor().timestamp > 0){
-                    Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than two readings missed :  " + newAlert.name);
+                    Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than three readings missed :  " + newAlert.name);
                     return;
                 }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -165,10 +165,13 @@ public class Notifications extends IntentService {
             if (activeBgAlert.uuid.equals(newAlert.uuid)) {
                 // This is the same alert. Might need to play again...
 
-                //if more than three readings missed, don't replay
-                if ((new Date().getTime()) - (60000 * 17) - BgReading.lastNoSenssor().timestamp > 0){
-                    Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than three readings missed :  " + newAlert.name);
-                    return;
+                //disable alert on stale data
+                if(prefs.getBoolean("disable_alerts_stale_data", true)) {
+                    int minutes = Integer.parseInt(prefs.getString("disable_alerts_stale_data_minutes", "15")) + 2;
+                    if ((new Date().getTime()) - (60000 * minutes) - BgReading.lastNoSenssor().timestamp > 0) {
+                        Log.d(TAG, "FileBasedNotifications : active alert found but not replaying it because more than three readings missed :  " + newAlert.name);
+                        return;
+                    }
                 }
 
                 Log.d(TAG, "FileBasedNotifications we have found an active alert, checking if we need to play it " + newAlert.name);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -245,6 +245,7 @@ public class Preferences extends PreferenceActivity {
             bindPreferenceSummaryToValueAndEnsureNumeric(findPreference("calibration_snooze"));
             bindPreferenceSummaryToValueAndEnsureNumeric(findPreference("bg_unclear_readings_minutes"));
             bindPreferenceSummaryToValueAndEnsureNumeric(findPreference("bg_missed_minutes"));
+            bindPreferenceSummaryToValueAndEnsureNumeric(findPreference("disable_alerts_stale_data_minutes"));
             bindPreferenceSummaryToValue(findPreference("falling_bg_val"));
             bindPreferenceSummaryToValue(findPreference("rising_bg_val"));
             bindPreferenceSummaryToValue(findPreference("other_alerts_sound"));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -21,6 +21,8 @@ import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
 import android.text.InputFilter;
 import android.text.TextUtils;
+import android.widget.Toast;
+
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 
 import com.eveningoutpost.dexdrip.R;
@@ -280,6 +282,22 @@ public class Preferences extends PreferenceActivity {
             final PreferenceScreen calibrationAlertsScreen = (PreferenceScreen) findPreference("calibration_alerts_screen");
             final PreferenceCategory alertsCategory = (PreferenceCategory) findPreference("alerts_category");
             final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+            final Preference disableAlertsStaleDataMinutes = findPreference("disable_alerts_stale_data_minutes");
+            disableAlertsStaleDataMinutes.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    if (!isNumeric(newValue.toString())) {
+                        return false;
+                    }
+                    if ((Integer.parseInt(newValue.toString())) < 10 ) {
+                        Toast.makeText(preference.getContext(),
+                                "Value must be at least 10 minutes", Toast.LENGTH_LONG).show();
+                        return false;
+                    }
+                    preference.setSummary(newValue.toString());
+                    return true;
+                }
+            });
             Log.d(TAG, prefs.getString("dex_collection_method", "BluetoothWixel"));
             if(prefs.getString("dex_collection_method", "BluetoothWixel").compareTo("DexcomShare") != 0) {
                 collectionCategory.removePreference(shareKey);

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -38,6 +38,20 @@
                 android:title="Shortcut to Bg Level Alerts"
                 android:summary="Create a shortcut from main navigation to bg level screen"
                 android:defaultValue="false" />
+
+                <CheckBoxPreference
+                    android:key="disable_alerts_stale_data"
+                    android:title="Suppress Snoozed Alerts if missed readings"
+                    android:summary="Suppress snoozed alerts if missed readings for a predefined period"
+                    android:defaultValue="true" />
+                <EditTextPreference
+                    android:dependency="disable_alerts_stale_data"
+                    android:key="disable_alerts_stale_data_minutes"
+                    android:title="Minutes after which to suppress snoozed alerts"
+                    android:inputType="number"
+                    android:summary="How many minutes of missed readings after which to suppress snoozed alerts"
+                    android:defaultValue="15" />
+
         </PreferenceScreen>
 
 
@@ -104,22 +118,6 @@
                     android:defaultValue="30" />
             </PreferenceCategory>
             
-            <PreferenceCategory
-                android:title="Stale Data">
-                <CheckBoxPreference
-                    android:key="disable_alerts_stale_data"
-                    android:title="Disable BG Alerts on Stale Data"
-                    android:summary="Disable BG Alerts on Stale Data"
-                    android:defaultValue="true" />
-                <EditTextPreference
-                    android:dependency="disable_alerts_stale_data"
-                    android:key="disable_alerts_stale_data_minutes"
-                    android:title="Minutes without reading after which to disable alerts"
-                    android:inputType="number"
-                    android:summary="Minutes without reading after which to disable alerts"
-                    android:defaultValue="15" />
-            </PreferenceCategory>
-
             <PreferenceCategory
                 android:title="Falling/Rising BG">
                 <CheckBoxPreference

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -41,15 +41,15 @@
 
                 <CheckBoxPreference
                     android:key="disable_alerts_stale_data"
-                    android:title="Suppress Snoozed Alerts if missed readings"
-                    android:summary="Suppress snoozed alerts if missed readings for a predefined period"
-                    android:defaultValue="true" />
+                    android:title="Suppress Alerts if missed readings"
+                    android:summary="Suppress snoozed and active alerts after predefined period of missed readings"
+                    android:defaultValue="false" />
                 <EditTextPreference
                     android:dependency="disable_alerts_stale_data"
                     android:key="disable_alerts_stale_data_minutes"
-                    android:title="Minutes after which to suppress snoozed alerts"
+                    android:title="Suppress snoozed and active alerts after .. minutes (minimum 10)"
                     android:inputType="number"
-                    android:summary="How many minutes of missed readings after which to suppress snoozed alerts"
+                    android:summary="Suppress snoozed and active alerts after .. minutes (minimum 10)"
                     android:defaultValue="15" />
 
         </PreferenceScreen>

--- a/app/src/main/res/xml/pref_notifications.xml
+++ b/app/src/main/res/xml/pref_notifications.xml
@@ -103,6 +103,22 @@
                     android:summary="Alert if no data receieved in x minutes"
                     android:defaultValue="30" />
             </PreferenceCategory>
+            
+            <PreferenceCategory
+                android:title="Stale Data">
+                <CheckBoxPreference
+                    android:key="disable_alerts_stale_data"
+                    android:title="Disable BG Alerts on Stale Data"
+                    android:summary="Disable BG Alerts on Stale Data"
+                    android:defaultValue="true" />
+                <EditTextPreference
+                    android:dependency="disable_alerts_stale_data"
+                    android:key="disable_alerts_stale_data_minutes"
+                    android:title="Minutes without reading after which to disable alerts"
+                    android:inputType="number"
+                    android:summary="Minutes without reading after which to disable alerts"
+                    android:defaultValue="15" />
+            </PreferenceCategory>
 
             <PreferenceCategory
                 android:title="Falling/Rising BG">


### PR DESCRIPTION
When someone stops using xdrip for a period, while xdrip app is in an alert status (active snoozed alert), .. reception is lost (normal), but the alert keeps going off.

This doesn't seem useful : if there's no signal, then either app will generate missedreading alert, or the user simply stopped using the xdrip for a while.

Happened here with 4 people that I know of using xdrip 
- two parents who use the xdrip only during the night, during the day when kid is at school alarm keeps going off
- two adults (me also) in the middle of the night - disabled bluetooth because using Dexcom receiver during the night, but snoozed alarm went off at 4 in the morning

The change is not to replay a snoozed alert when no reading for more than 10 minutes
