### PR TITLE
Avoid going to the network when we just received a packet 

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/WixelReader.java
@@ -36,7 +36,9 @@ public class WixelReader extends AsyncTask<String, Void, Void > {
     private static BgToSpeech bgToSpeech;
 
     private final Context mContext;
-    PowerManager.WakeLock wakeLock; 
+    PowerManager.WakeLock wakeLock;
+
+    private final static long DEXCOM_PERIOD=300000;
     
     private static int lockCounter = 0;
     
@@ -301,7 +303,7 @@ public class WixelReader extends AsyncTask<String, Void, Void > {
     }
 
     static Long timeForNextRead() {
-        final long DEXCOM_PERIOD=300000;
+
         TransmitterData lastTransmitterData = TransmitterData.last();
         if(lastTransmitterData == null) {
             // We did not receive a packet, well someone hopefully is looking at data, return relatively fast
@@ -353,9 +355,17 @@ public class WixelReader extends AsyncTask<String, Void, Void > {
     	TransmitterData lastTransmitterData = TransmitterData.last();
     	if(lastTransmitterData != null) {
     	    LastReportedTime = lastTransmitterData.timestamp;
-    	}
+
+            // jamorham fix to avoid going twice to network when we just got a packet
+            if ((new Date().getTime() - LastReportedTime) < DEXCOM_PERIOD-2000) {
+            Log.d(TAG, "Already have a recent packet - returning");
+            return;
+            }
+
+
+        }
     	Long startReadTime = LastReportedTime;
-    	
+
     	TransmitterRawData LastReportedReading = null;
     	Log.d(TAG, "Starting... LastReportedReading " + LastReportedReading);
     	// try to read one object...


### PR DESCRIPTION
This patch avoids the situation where a wifi-wixel request goes out and succeeds getting the latest data and then 10 seconds later tries again regardless.

The issue is caused by the timer being armed before the network request is made. This additional check prevents going to the network when we already have the most recent packet.

In ideal conditions this will halve network usage with wifi wixel mode.
