### PR TITLE
Create index for bgreadings(timestamp)

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -1,8 +1,10 @@
 package com.eveningoutpost.dexdrip;
 
 import android.app.Application;
+import android.database.sqlite.SQLiteDatabase;
 import android.preference.PreferenceManager;
 
+import com.activeandroid.Cache;
 import com.crashlytics.android.Crashlytics;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.IdempotentMigrations;
@@ -19,12 +21,16 @@ public class xdrip extends Application {
     public void onCreate() {
         super.onCreate();
         Fabric.with(this, new Crashlytics());
-        CollectionServiceStarter collectionServiceStarter = new CollectionServiceStarter(getApplicationContext());
-        collectionServiceStarter.start(getApplicationContext());
+        CollectionServiceStarter collectionServiceStarter = new CollectionServiceStarter(this);
+        collectionServiceStarter.start(this);
         PreferenceManager.setDefaultValues(this, R.xml.pref_general, false);
         PreferenceManager.setDefaultValues(this, R.xml.pref_data_sync, false);
         PreferenceManager.setDefaultValues(this, R.xml.pref_notifications, false);
         PreferenceManager.setDefaultValues(this, R.xml.pref_data_source, false);
-        new IdempotentMigrations(getApplicationContext()).performAll();
+        new IdempotentMigrations(this).performAll();
+
+        //create index
+        SQLiteDatabase db = Cache.openDatabase();
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS bgtimestampindex ON bgreadings(timestamp)");
     }
 }


### PR DESCRIPTION
@mgranberry: This would be an index on  bgreadings(timestamp) like you suggested. Does it look ok?

I thought the installation would be a good place (at least to test it). Another place I thought of were the db migrations. But that would increase the schema version number and make db's incompatible for export/reimport.

So far it at least didn't have a negative effect that I could notice.
