### PR TITLE
Examples for a DataPluginInterface

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataProvider.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataProvider.java
@@ -1,0 +1,42 @@
+package com.eveningoutpost.dexdrip.DataPlugins;
+
+/**
+ * Created by adrian on 09/12/15.
+ */
+public interface DataProvider{
+
+    //TODO: write proper JavaDoc ;)
+
+    /*
+    * Register a DataReceiver that will receive callbacks when new data is available.
+    * The registration of the first DataReceiver may start background services or tasks for data retrieval.
+    * */
+    public void registerDataReceiver(DataReceiver dataReceiver);
+
+
+    /*
+    * Like registerDataReceiver(DataReceiver dataReceiver) but only expects callbacks for a certain type.
+    * This might save load as the DataProvider only has to retrieve data for types that are registered for
+    * **/
+    public void registerDataReceiver(DataReceiver dataReceiver, String type);
+
+
+    /*
+    * Register for several types of data.
+    * */
+    public void registerDataReceiver(DataReceiver dataReceiver, String[] types);
+
+
+    /*
+      Will deregister a DataReceiver.
+    * In case the count of registered receivers reaches 0, all data retrieval services or tasks
+    * that may have been started will get stopped.
+    * */
+    public void deregisterDataReceiver(DataReceiver dataReceiver);
+
+    /*
+    * Will deregister all DataReceivers.
+    * In case a Service or Background task is started it will be stopped.
+    * */
+    public void tearDown();
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataReceiver.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataReceiver.java
@@ -1,0 +1,12 @@
+package com.eveningoutpost.dexdrip.DataPlugins;
+
+import android.os.Bundle;
+
+/**
+ * Created by adrian on 09/12/15.
+ */
+public interface DataReceiver {
+
+    public void onNewDataReceived(String type, Bundle data);
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataReceiverProposal2.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataReceiverProposal2.java
@@ -1,0 +1,14 @@
+package com.eveningoutpost.dexdrip.DataPlugins;
+
+import android.os.Bundle;
+
+/**
+ * Created by adrian on 09/12/15.
+ */
+public interface DataReceiverProposal2 {
+
+    public void onNewBgData(Bundle data);
+    public void onNewCalData(Bundle data);
+    public void onNewMeterReading(Bundle data);
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataReceiverProposal3.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/DataPlugins/DataReceiverProposal3.java
@@ -1,0 +1,16 @@
+package com.eveningoutpost.dexdrip.DataPlugins;
+
+import android.support.annotation.Nullable;
+
+/**
+ * Created by adrian on 09/12/15.
+ */
+public interface DataReceiverProposal3 {
+
+    public void onNewCalData(long timestamp, double slope, double intercept, @Nullable Double scale, @Nullable Double raw_filtered, @Nullable Double raw_unfiltered);
+    public void onNewMeterReading(long timestamp); //add more parameters
+    public void onNewBgData(long timestamp); //add more parameters
+
+    //Add more functions. Every new Datatype the Library can handle would need a new function-stub
+
+}


### PR DESCRIPTION
Hi,

I'd like to propose an plugin interface for new data sources for xDrip (and probably other apps).
I'm not fixated on a certain design pattern but I generally like registering and callbacks. Some kind of more general Data-Broker might also be good but without experience I would guess it would be much more work to implement it than anyone has time at the moment?
The Interfaces in this PR are for illustration.

A defined Interface like this has the advantage from the xDrip side, that once a `DataReceiver` is implemented to map the data to the xDrip datastructure, other data retrieval methods can simply be plugged in. E.g. one that retrieves the data from a Share server or even another one for NightScout that gets the data pushed by the server rather than pulls it. The only thing that might have to change is one line of setup code, passing connection strings or similar.

From the side of re-usability: Other android programmes could easily reuse the Library. I'm thinking of an AndroidWear watchface that can show the data without the need of a connected Android phone (data via wifi, gsm, iPhone,...).

To integrate Tzachi's NightScout query methods, we could write a service that actually calls the query methods. This service would also implement `DataProvider`. For xDrip we have to find a way to map NighScout and ShareServer and... data to the xDrip datastructure anyways. This will be the next big task for any form of NightScout integration. At this point in time, writing a `DataReceiver` that does the job won't be more work but would give us much less problems in the future.

There would be different kind of flexibility we would have to choose between with the interface of DataReceiver. It seems to be a tradeoff between simplicity plus covering all cases now and the easy possibility to add more data types to just one library (like IOB, COB, ...) and other treatment and AP related things.

cheers, Adrian
