### PR TITLE
Calibration timestamp fixes

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -38,7 +38,7 @@ public class Calibration extends Model {
 
     @Expose
     @Column(name = "timestamp", index = true)
-    public double timestamp;
+    public long timestamp;
 
     @Expose
     @Column(name = "sensor_age_at_time_of_estimation")
@@ -73,7 +73,7 @@ public class Calibration extends Model {
 
     @Expose
     @Column(name = "raw_timestamp")
-    public double raw_timestamp;
+    public long raw_timestamp;
 
     @Expose
     @Column(name = "slope")
@@ -255,6 +255,7 @@ public class Calibration extends Model {
                     Calibration calibration = new Calibration();
                     calibration.bg = calSubrecord.getCalBGL();
                     calibration.timestamp = calSubrecord.getDateEntered().getTime() + addativeOffset;
+                    calibration.raw_timestamp = calibration.timestamp;
                     if (calibration.timestamp > new Date().getTime()) {
                         Log.d(TAG, "ERROR - Calibration timestamp is from the future, wont save!");
                         return;


### PR DESCRIPTION
I hope this fixes the issue with wrong times shown in the calibration graph with ShareReceiver generated data. (I have no Share to test that.)
