### PR TITLE
Edit Alert overhaul

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/AlertList.java
@@ -203,9 +203,9 @@ public class AlertList extends ActivityWithMenu {
         return "";
     }
 
-    public String timeFormatString(int Hour, int Minute) {
+    public String timeFormatString(int hour, int minute) {
         SimpleDateFormat timeFormat24 = new SimpleDateFormat("HH:mm");
-        String selected = Hour+":"+Minute;
+        String selected = hour+":" + ((minute<10)?"0":"") + minute;
         if (!android.text.format.DateFormat.is24HourFormat(mContext)) {
             try {
                 Date date = timeFormat24.parse(selected);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -326,7 +326,7 @@ public class EditAlertActivity extends ActivityWithMenu {
         // We want to make sure that for each threashold there is only one alert. Otherwise, which file should we play.
         for (AlertType lowAlert : lowAlerts) {
             if(lowAlert.threshold == threshold  && overlapping(lowAlert, allDay, startTime, endTime)) {
-                if(uuid == null || uuid != lowAlert.uuid){ //new alert or not myself
+                if(uuid == null || ! uuid.equals(lowAlert.uuid)){ //new alert or not myself
                     Toast.makeText(getApplicationContext(),
                             "Each alert should have it's own threshold. Please choose another threshold.",Toast.LENGTH_LONG).show();
                     return false;
@@ -335,7 +335,7 @@ public class EditAlertActivity extends ActivityWithMenu {
         }
         for (AlertType highAlert : highAlerts) {
             if(highAlert.threshold == threshold  && overlapping(highAlert, allDay, startTime, endTime)) {
-                if(uuid == null || uuid != highAlert.uuid){ //new alert or not myself
+                if(uuid == null || ! uuid.equals(highAlert.uuid)){ //new alert or not myself
                     Toast.makeText(getApplicationContext(),
                             "Each alert should have it's own threshold. Please choose another threshold.",Toast.LENGTH_LONG).show();
                     return false;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/EditAlertActivity.java
@@ -323,23 +323,26 @@ public class EditAlertActivity extends ActivityWithMenu {
             Toast.makeText(getApplicationContext(), "threshold has to be between " +unitsConvert2Disp(doMgdl, MIN_ALERT) + " and " + unitsConvert2Disp(doMgdl, MAX_ALERT),Toast.LENGTH_LONG).show();
             return false;
         }
-        if (uuid == null) {
-            // We want to make sure that for each threashold there is only one alert. Otherwise, which file should we play.
-            for (AlertType lowAlert : lowAlerts) {
-                if(lowAlert.threshold == threshold  && overlapping(lowAlert, allDay, startTime, endTime)) {
-                    Toast.makeText(getApplicationContext(),
-                            "Each alert should have it's own threshold. Please choose another threshold.",Toast.LENGTH_LONG).show();
-                    return false;
-                }
-            }
-            for (AlertType highAlert : highAlerts) {
-                if(highAlert.threshold == threshold  && overlapping(highAlert, allDay, startTime, endTime)) {
+        // We want to make sure that for each threashold there is only one alert. Otherwise, which file should we play.
+        for (AlertType lowAlert : lowAlerts) {
+            if(lowAlert.threshold == threshold  && overlapping(lowAlert, allDay, startTime, endTime)) {
+                if(uuid == null || uuid != lowAlert.uuid){ //new alert or not myself
                     Toast.makeText(getApplicationContext(),
                             "Each alert should have it's own threshold. Please choose another threshold.",Toast.LENGTH_LONG).show();
                     return false;
                 }
             }
         }
+        for (AlertType highAlert : highAlerts) {
+            if(highAlert.threshold == threshold  && overlapping(highAlert, allDay, startTime, endTime)) {
+                if(uuid == null || uuid != highAlert.uuid){ //new alert or not myself
+                    Toast.makeText(getApplicationContext(),
+                            "Each alert should have it's own threshold. Please choose another threshold.",Toast.LENGTH_LONG).show();
+                    return false;
+                }
+            }
+        }
+
         // high alerts have to be higher than all low alerts...
         if(above) {
             for (AlertType lowAlert : lowAlerts) {
@@ -379,6 +382,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                 st1 <= st2 && (et2 < st2) && et2 > st1 || //2nd timeframe passes midnight
                 st2 <= st1 && et2 > st1 ||
                 st2 <= st1 && (et1 < st1) && et1 > st2; //1st timeframe passes midnight
+
     }
 
     private double parseDouble(String str) {
@@ -550,7 +554,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                         startMinute = selectedMinute;
                         setTimeRanges();
                     }
-                }, 0, 0, DateFormat.is24HourFormat(mContext));
+                }, startHour, startMinute, DateFormat.is24HourFormat(mContext));
                 mTimePicker.setTitle("Select Time");
                 mTimePicker.show();
 
@@ -568,7 +572,7 @@ public class EditAlertActivity extends ActivityWithMenu {
                         endMinute = selectedMinute;
                         setTimeRanges();
                     }
-                }, 23, 59, DateFormat.is24HourFormat(mContext));
+                }, endHour, endMinute, DateFormat.is24HourFormat(mContext));
                 mTimePicker.setTitle("Select Time");
                 mTimePicker.show();
 
@@ -631,9 +635,9 @@ public class EditAlertActivity extends ActivityWithMenu {
         }
     }
 
-    public String timeFormatString(int Hour, int Minute) {
+    public String timeFormatString(int hour, int minute) {
         SimpleDateFormat timeFormat24 = new SimpleDateFormat("HH:mm");
-        String selected = Hour+":"+Minute;
+        String selected = hour+":" + ((minute<10)?"0":"") + minute;
         if (!DateFormat.is24HourFormat(mContext)) {
             try {
                 Date date = timeFormat24.parse(selected);


### PR DESCRIPTION
This PR solves 4 issues with the EditAlertActivity reported over the last couple of month:
- Threshold validity checks were only made for newly created alerts. It was possible to add a valid alert and then change the threshold to the one of another existing alert.
- A high alert and a low alert would collide and be rejected if the low alert was higher than the high alert. Even if they were at totally different times of the day. E.g. Low-Alert of 150mg/dl when doing sports in the afternoon would not be possible with a high alert of 145mg/dl just during the night. Now it checks if they are overlapping before rejecting them
- Minutes below 10 would show with just one digit. 9:05 am would show as 9:5.
- The TimePicker did always have 0:00 or 23:59 when opening it -> now it starts with the time previously selected.
