### PR TITLE
Fix a bug that caused timer to be fired all the time.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/AutoStart.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/AutoStart.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
+import com.eveningoutpost.dexdrip.Services.MissedReadingService;
 
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 
@@ -15,5 +16,6 @@ public class AutoStart extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         Log.d("DexDrip", "Service auto starter, starting!");
         CollectionServiceStarter.newStart(context);
+        context.startService(new Intent(context, MissedReadingService.class));
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/MissedReadingService.java
@@ -48,11 +48,9 @@ public class MissedReadingService extends IntentService {
         otherAlertSnooze =  Integer.parseInt(prefs.getString("other_alerts_snooze", "20"));
 
         long now = new Date().getTime();
-        
+        Log.d(TAG, "MissedReadingService onHandleIntent");
         if (!bg_missed_alerts) {
-        	// we should not do anything in this case. Until there is a listener on UI changes, try again in 5 minutes
-            Log.d(TAG, "Setting timer to  5 minutes from now" );
-            checkBackAfterMissedTime(now + 5 * 60 *1000);
+        	// we should not do anything in this case. if the ui, changes will be called again
         	return;
         }
 
@@ -64,14 +62,14 @@ public class MissedReadingService extends IntentService {
             
             long disabletime = prefs.getLong("alerts_disabled_until", 0) - now;
             
-            long missedTime = Long.parseLong(prefs.getString("bg_missed_minutes", "30"))* 1000 * 60 - BgReading.getTimeSinceLastReading();
+            long missedTime = bg_missed_minutes* 1000 * 60 - BgReading.getTimeSinceLastReading();
             long alarmIn = Math.max(disabletime, missedTime);
-            Log.d(TAG, "Setting timer to  " + alarmIn / 60000 + " minutes from now" );
             checkBackAfterMissedTime(alarmIn);
         }
     }
 
     public void checkBackAfterSnoozeTime() {
+    	// This is not 100% acurate, need to take in account also the time of when this alert was snoozed.
         setAlarm(otherAlertSnooze * 1000 * 60);
     }
 
@@ -80,6 +78,7 @@ public class MissedReadingService extends IntentService {
     }
 
     public void setAlarm(long alarmIn) {
+    	Log.d(TAG, "Setting timer to  " + alarmIn / 60000 + " minutes from now" );
         Calendar calendar = Calendar.getInstance();
         AlarmManager alarm = (AlarmManager) getSystemService(ALARM_SERVICE);
         long wakeTime = calendar.getTimeInMillis() + alarmIn;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -24,7 +24,7 @@ import android.text.TextUtils;
 import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
-
+import com.eveningoutpost.dexdrip.Services.MissedReadingService;
 import com.eveningoutpost.dexdrip.R;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
 import com.eveningoutpost.dexdrip.UtilityModels.PebbleSync;
@@ -268,6 +268,7 @@ public class Preferences extends PreferenceActivity {
             addPreferencesFromResource(R.xml.pref_community_help);
 
             bindTTSListener();
+            bindBgMissedAlertsListener();
             final Preference collectionMethod = findPreference("dex_collection_method");
             final Preference runInForeground = findPreference("run_service_in_foreground");
             final Preference wifiRecievers = findPreference("wifi_recievers_addresses");
@@ -467,6 +468,18 @@ public class Preferences extends PreferenceActivity {
                     return true;
                 }
             });
+        }
+        
+        private void bindBgMissedAlertsListener(){
+        	findPreference("bg_missed_alerts").setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+        
+	            @Override
+	            public boolean onPreferenceChange(Preference preference, Object newValue) {
+	            	Context context = preference.getContext();
+	            	context.startService(new Intent(context, MissedReadingService.class));
+	            	return true;
+	            }
+        	});
         }
 
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/Preferences.java
@@ -469,17 +469,21 @@ public class Preferences extends PreferenceActivity {
                 }
             });
         }
+
+        private static Preference.OnPreferenceChangeListener sBgMissedAlertsHandler = new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Context context = preference.getContext();
+                context.startService(new Intent(context, MissedReadingService.class));
+                return true;
+            }
+        };
+
         
         private void bindBgMissedAlertsListener(){
-        	findPreference("bg_missed_alerts").setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-        
-	            @Override
-	            public boolean onPreferenceChange(Preference preference, Object newValue) {
-	            	Context context = preference.getContext();
-	            	context.startService(new Intent(context, MissedReadingService.class));
-	            	return true;
-	            }
-        	});
+          findPreference("bg_missed_alerts").setOnPreferenceChangeListener(sBgMissedAlertsHandler);
+          findPreference("bg_missed_minutes").setOnPreferenceChangeListener(sBgMissedAlertsHandler);
+          findPreference("other_alerts_snooze").setOnPreferenceChangeListener(sBgMissedAlertsHandler);
         }
 
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -2,6 +2,10 @@ package com.eveningoutpost.dexdrip;
 
 import android.app.Application;
 import android.preference.PreferenceManager;
+import android.content.Context;
+import android.content.Intent;
+
+import com.eveningoutpost.dexdrip.Services.MissedReadingService;
 
 import com.crashlytics.android.Crashlytics;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
@@ -19,12 +23,14 @@ public class xdrip extends Application {
     public void onCreate() {
         super.onCreate();
         Fabric.with(this, new Crashlytics());
-        CollectionServiceStarter collectionServiceStarter = new CollectionServiceStarter(getApplicationContext());
+        Context context = getApplicationContext();
+        CollectionServiceStarter collectionServiceStarter = new CollectionServiceStarter(context);
         collectionServiceStarter.start(getApplicationContext());
         PreferenceManager.setDefaultValues(this, R.xml.pref_general, false);
         PreferenceManager.setDefaultValues(this, R.xml.pref_data_sync, false);
         PreferenceManager.setDefaultValues(this, R.xml.pref_notifications, false);
         PreferenceManager.setDefaultValues(this, R.xml.pref_data_source, false);
+        context.startService(new Intent(context, MissedReadingService.class));	
         new IdempotentMigrations(getApplicationContext()).performAll();
     }
 }


### PR DESCRIPTION
This has happened in the case that no missing reading alerts has happened and no packets were coming in.
Also use a smarter condition on when to fire the alert.

Still under test.
