### PR TITLE
Send queue improvments

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/SyncService.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/SyncService.java
@@ -37,8 +37,10 @@ public class SyncService extends IntentService {
         attemptSend();
     }
 
-    public void attemptSend() {
-        if (enableRESTUpload || enableMongoUpload) { syncToMogoDb(); }
+    private void attemptSend() {
+        if (enableRESTUpload || enableMongoUpload) { 
+            syncToMogoDb(); 
+        }
         setRetryTimer();
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -56,18 +56,10 @@ public class BgSendQueue extends Model {
                 .orderBy("_ID desc")
                 .limit(nightWatchproMode ? 500 : 30)
                 .execute();
-    	if (!nightWatchproMode) {
-    		return values;
+    	if (nightWatchproMode) {
+    		 java.util.Collections.reverse(values);
     	}
-    	// swap the order of objects
-    	ArrayList<BgSendQueue> ret = new ArrayList<BgSendQueue>(values.size());	
-
-		int location = values.size() - 1;
-		for(BgSendQueue value : values) {
-			ret.set(location, value);
-			location--;
-		}
-		return ret;
+    	return values;
     	
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -47,23 +47,13 @@ public class BgSendQueue extends Model {
     @Column(name = "operation_type")
     public String operation_type;
 
-/*
-    public static List<BgSendQueue> queue() {
-        return new Select()
-                .from(BgSendQueue.class)
-                .where("success = ?", false)
-                .orderBy("_ID asc")
-                .limit(20)
-                .execute();
-    }
-*/
     public static List<BgSendQueue> mongoQueue() {
         return new Select()
                 .from(BgSendQueue.class)
                 .where("mongo_success = ?", false)
                 .where("operation_type = ?", "create")
                 .orderBy("_ID asc")
-                .limit(3)
+                .limit(300)
                 .execute();
     }
 
@@ -83,7 +73,8 @@ public class BgSendQueue extends Model {
                 "sendQueue");
         wakeLock.acquire();
         try {
-            addToQueue(bgReading, operation_type);
+        	
+       		addToQueue(bgReading, operation_type);
 
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
@@ -172,10 +163,9 @@ public class BgSendQueue extends Model {
             wakeLock.release();
         }
     }
-
-    public void markMongoSuccess() {
-        mongo_success = true;
-        save();
+    
+    public void deleteThis() {
+        this.delete();
     }
 
     public static int getBatteryLevel(Context context) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -27,6 +27,7 @@ import com.eveningoutpost.dexdrip.ShareModels.BgUploader;
 import com.eveningoutpost.dexdrip.WidgetUpdateService;
 import com.eveningoutpost.dexdrip.xDripWidget;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -47,14 +48,27 @@ public class BgSendQueue extends Model {
     @Column(name = "operation_type")
     public String operation_type;
 
-    public static List<BgSendQueue> mongoQueue() {
-        return new Select()
+    public static List<BgSendQueue> mongoQueue(boolean nightWatchproMode) {
+    	List<BgSendQueue> values = new Select()
                 .from(BgSendQueue.class)
                 .where("mongo_success = ?", false)
                 .where("operation_type = ?", "create")
-                .orderBy("_ID asc")
-                .limit(300)
+                .orderBy("_ID desc")
+                .limit(nightWatchproMode ? 500 : 30)
                 .execute();
+    	if (!nightWatchproMode) {
+    		return values;
+    	}
+    	// swap the order of objects
+    	ArrayList<BgSendQueue> ret = new ArrayList<BgSendQueue>(values.size());	
+
+		int location = values.size() - 1;
+		for(BgSendQueue value : values) {
+			ret.set(location, value);
+			location--;
+		}
+		return ret;
+    	
     }
 
     private static void addToQueue(BgReading bgReading, String operation_type) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -48,15 +48,15 @@ public class BgSendQueue extends Model {
     @Column(name = "operation_type")
     public String operation_type;
 
-    public static List<BgSendQueue> mongoQueue(boolean nightWatchproMode) {
+    public static List<BgSendQueue> mongoQueue(boolean xDripViewerMode) {
     	List<BgSendQueue> values = new Select()
                 .from(BgSendQueue.class)
                 .where("mongo_success = ?", false)
                 .where("operation_type = ?", "create")
                 .orderBy("_ID desc")
-                .limit(nightWatchproMode ? 500 : 30)
+                .limit(xDripViewerMode ? 500 : 30)
                 .execute();
-    	if (nightWatchproMode) {
+    	if (xDripViewerMode) {
     		 java.util.Collections.reverse(values);
     	}
     	return values;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -62,8 +62,8 @@ public class BgSendQueue extends Model {
                 .from(BgSendQueue.class)
                 .where("mongo_success = ?", false)
                 .where("operation_type = ?", "create")
-                .orderBy("_ID desc")
-                .limit(30)
+                .orderBy("_ID asc")
+                .limit(3)
                 .execute();
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
@@ -41,8 +41,8 @@ public class CalibrationSendQueue extends Model {
         return new Select()
                 .from(CalibrationSendQueue.class)
                 .where("mongo_success = ?", false)
-                .orderBy("_ID desc")
-                .limit(20)
+                .orderBy("_ID asc")
+                .limit(2)
                 .execute();
     }
     public static void addToQueue(Calibration calibration, Context context) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
@@ -11,6 +11,7 @@ import com.activeandroid.annotation.Table;
 import com.activeandroid.query.Select;
 import com.eveningoutpost.dexdrip.Models.Calibration;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -28,13 +29,26 @@ public class CalibrationSendQueue extends Model {
     @Column(name = "mongo_success", index = true)
     public boolean mongo_success;
 
-    public static List<CalibrationSendQueue> mongoQueue() {
-        return new Select()
+    public static List<CalibrationSendQueue> mongoQueue(boolean nightWatchproMode) {
+    	List<CalibrationSendQueue> values =  new Select()
                 .from(CalibrationSendQueue.class)
                 .where("mongo_success = ?", false)
-                .orderBy("_ID asc")
-                .limit(2)
+                .orderBy("_ID desc")
+                .limit(4)
                 .execute();
+        
+    	if (!nightWatchproMode) {
+    		return values;
+    	}
+    	// swap the order of objects
+    	ArrayList<CalibrationSendQueue> ret = new ArrayList<CalibrationSendQueue>(values.size());	
+
+		int location = values.size() - 1;
+		for(CalibrationSendQueue value : values) {
+			ret.set(location, value);
+			location--;
+		}
+		return ret;
     }
     public static void addToQueue(Calibration calibration, Context context) {
         CalibrationSendQueue calibrationSendQueue = new CalibrationSendQueue();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
@@ -29,7 +29,7 @@ public class CalibrationSendQueue extends Model {
     @Column(name = "mongo_success", index = true)
     public boolean mongo_success;
 
-    public static List<CalibrationSendQueue> mongoQueue(boolean nightWatchproMode) {
+    public static List<CalibrationSendQueue> mongoQueue(boolean xDripViewerMode) {
     	List<CalibrationSendQueue> values =  new Select()
                 .from(CalibrationSendQueue.class)
                 .where("mongo_success = ?", false)
@@ -37,7 +37,7 @@ public class CalibrationSendQueue extends Model {
                 .limit(4)
                 .execute();
         
-    	if (nightWatchproMode) {
+    	if (xDripViewerMode) {
    		 	java.util.Collections.reverse(values);
     	}
     	return values;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
@@ -28,15 +28,6 @@ public class CalibrationSendQueue extends Model {
     @Column(name = "mongo_success", index = true)
     public boolean mongo_success;
 
-    /*
-    public static List<CalibrationSendQueue> queue() {
-        return new Select()
-                .from(CalibrationSendQueue.class)
-                .where("success = ?", false)
-                .orderBy("_ID asc")
-                .execute();
-    }
-    */
     public static List<CalibrationSendQueue> mongoQueue() {
         return new Select()
                 .from(CalibrationSendQueue.class)
@@ -52,9 +43,8 @@ public class CalibrationSendQueue extends Model {
         calibrationSendQueue.mongo_success = false;
         calibrationSendQueue.save();
     }
-
-    public void markMongoSuccess() {
-        mongo_success = true;
-        save();
+    
+    public void deleteThis() {
+        this.delete();
     }
 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/CalibrationSendQueue.java
@@ -37,18 +37,10 @@ public class CalibrationSendQueue extends Model {
                 .limit(4)
                 .execute();
         
-    	if (!nightWatchproMode) {
-    		return values;
+    	if (nightWatchproMode) {
+   		 	java.util.Collections.reverse(values);
     	}
-    	// swap the order of objects
-    	ArrayList<CalibrationSendQueue> ret = new ArrayList<CalibrationSendQueue>(values.size());	
-
-		int location = values.size() - 1;
-		for(CalibrationSendQueue value : values) {
-			ret.set(location, value);
-			location--;
-		}
-		return ret;
+    	return values;
     }
     public static void addToQueue(Calibration calibration, Context context) {
         CalibrationSendQueue calibrationSendQueue = new CalibrationSendQueue();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
@@ -1,8 +1,10 @@
 package com.eveningoutpost.dexdrip.UtilityModels;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.PowerManager;
+import android.preference.PreferenceManager;
 
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import com.eveningoutpost.dexdrip.Models.BgReading;
@@ -17,8 +19,6 @@ import java.util.List;
  */
 public class MongoSendTask extends AsyncTask<String, Void, Void> {
         private Context context;
-        //public List<BgSendQueue> bgsQueue = new ArrayList<BgSendQueue>();
-        public List<CalibrationSendQueue> calibrationsQueue = new ArrayList<CalibrationSendQueue>();
 
         PowerManager.WakeLock wakeLock;
         private static int lockCounter = 0;
@@ -47,7 +47,8 @@ public class MongoSendTask extends AsyncTask<String, Void, Void> {
         }
         
         private boolean sendData() {
-        	boolean nightWatchproMode = false;//???????
+        	SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        	boolean nightWatchproMode = prefs.getBoolean("nightwatchpro_upload_mode", false);
             List<CalibrationSendQueue>calibrationsQueue = CalibrationSendQueue.mongoQueue(nightWatchproMode);
             List<BgSendQueue> bgsQueue = BgSendQueue.mongoQueue( nightWatchproMode);
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
@@ -44,8 +44,9 @@ public class MongoSendTask extends AsyncTask<String, Void, Void> {
             } finally {
                 wakeLock.release();
                 lockCounter--;
-                Log.e(TAG,"wakelock released " + lockCounter);
+                Log.e(TAG,"MongosendTask wakelock released " + lockCounter);
             }
+            return null;
         }
         
         private boolean sendData() {
@@ -67,12 +68,17 @@ public class MongoSendTask extends AsyncTask<String, Void, Void> {
                     NightscoutUploader uploader = new NightscoutUploader(context);
                     boolean uploadStatus = uploader.upload(bgReadings, calibrations, calibrations);
                     if (uploadStatus) {
+                    	Log.i(TAG, "Starting to delete objects from queue " + bgsQueue.size() + calibrationsQueue.size());
                         for (CalibrationSendQueue calibration : calibrationsQueue) {
-                            calibration.markMongoSuccess();
+                            calibration.deleteThis();
                         }
                         for (BgSendQueue bgReading : bgsQueue) {
-                            bgReading.markMongoSuccess();
+                            bgReading.deleteThis();
                         }
+                        Log.i(TAG, "finished deleting objects from queue " + bgReadings.size());
+                    } else {
+                    	Log.e(TAG, "uploader.upload returned false - exiting");
+                    	return false;
                     }
                 } else {
                     return false;
@@ -86,8 +92,4 @@ public class MongoSendTask extends AsyncTask<String, Void, Void> {
             return true;
         }
 
-//        protected void onPostExecute(RSSFeed feed) {
-//            // TODO: check this.exception
-//            // TODO: do something with the feed
-//        }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
@@ -48,7 +48,7 @@ public class MongoSendTask extends AsyncTask<String, Void, Void> {
         
         private boolean sendData() {
         	SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        	boolean nightWatchproMode = prefs.getBoolean("nightwatchpro_upload_mode", false);
+        	boolean nightWatchproMode = prefs.getBoolean("xDripViewer_upload_mode", false);
             List<CalibrationSendQueue>calibrationsQueue = CalibrationSendQueue.mongoQueue(nightWatchproMode);
             List<BgSendQueue> bgsQueue = BgSendQueue.mongoQueue( nightWatchproMode);
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/MongoSendTask.java
@@ -48,9 +48,9 @@ public class MongoSendTask extends AsyncTask<String, Void, Void> {
         
         private boolean sendData() {
         	SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        	boolean nightWatchproMode = prefs.getBoolean("xDripViewer_upload_mode", false);
-            List<CalibrationSendQueue>calibrationsQueue = CalibrationSendQueue.mongoQueue(nightWatchproMode);
-            List<BgSendQueue> bgsQueue = BgSendQueue.mongoQueue( nightWatchproMode);
+        	boolean xDripViewerMode = prefs.getBoolean("xDripViewer_upload_mode", false);
+            List<CalibrationSendQueue>calibrationsQueue = CalibrationSendQueue.mongoQueue(xDripViewerMode);
+            List<BgSendQueue> bgsQueue = BgSendQueue.mongoQueue( xDripViewerMode);
 
             try {
                 List<BgReading> bgReadings = new ArrayList<BgReading>();
@@ -65,7 +65,7 @@ public class MongoSendTask extends AsyncTask<String, Void, Void> {
                 if(bgReadings.size() + calibrations.size() > 0) {
                 	Log.i(TAG, "uoader.upload called " + bgReadings.size());
                     NightscoutUploader uploader = new NightscoutUploader(context);
-                    boolean uploadStatus = uploader.upload(bgReadings, calibrations, calibrations, nightWatchproMode);
+                    boolean uploadStatus = uploader.upload(bgReadings, calibrations, calibrations, xDripViewerMode);
                     if (uploadStatus) {
                     	Log.i(TAG, "Starting to delete objects from queue " + bgsQueue.size() + calibrationsQueue.size());
                         for (CalibrationSendQueue calibration : calibrationsQueue) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -177,7 +177,6 @@ public class NightscoutUploader {
 
         private void doRESTUploadTo(NightscoutService nightscoutService, String secret, List<BgReading> glucoseDataSets, List<Calibration> meterRecords, List<Calibration> calRecords) throws Exception {
             JSONArray array = new JSONArray();
-
             for (BgReading record : glucoseDataSets) {
                 populateV1APIBGEntry(array, record);
             }
@@ -216,6 +215,7 @@ public class NightscoutUploader {
             json.put("xDrip_filtered", record.filtered_data);
             json.put("xDrip_calculated_value", record.calculated_value);
             json.put("xDrip_age_adjusted_raw_value", record.age_adjusted_raw_value);
+            json.put("sysTime", format.format(record.timestamp));
             array.put(json);
         }
 
@@ -246,6 +246,7 @@ public class NightscoutUploader {
             json.put("xDrip_slope_confidence", record.slope_confidence);
             json.put("xDrip_sensor_confidence", record.sensor_confidence);
             json.put("xDrip_raw_timestamp", record.raw_timestamp);
+            json.put("sysTime", format.format(record.timestamp));
             array.put(json);
         }
 
@@ -266,6 +267,7 @@ public class NightscoutUploader {
                 json.put("intercept", (long) ((record.intercept * -1000) / (record.slope * 1000)));
                 json.put("scale", 1);
             }
+            json.put("sysTime", format.format(record.timestamp));
             array.put(json);
         }
 
@@ -324,7 +326,6 @@ public class NightscoutUploader {
                             testData.put("xDrip_calculated_value", record.calculated_value);
                             testData.put("xDrip_age_adjusted_raw_value", record.age_adjusted_raw_value);
                             
-
                             testData.put("sysTime", format.format(record.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "sgv").append("sysTime", format.format(record.timestamp));
                             dexcomData.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -347,6 +347,14 @@ public class NightscoutUploader {
                             testData.put("date", meterRecord.timestamp);
                             testData.put("dateString", format.format(meterRecord.timestamp));
                             testData.put("mbg", meterRecord.bg);
+                            if(nightWatchproMode) {
+	                            testData.put("xDrip_slope", calRecord.slope);
+	                            testData.put("xDrip_intercept", calRecord.intercept);
+	                            testData.put("xDrip_estimate_raw_at_time_of_calibration", calRecord.estimate_raw_at_time_of_calibration);
+	                            testData.put("xDrip_slope_confidence", calRecord.slope_confidence);
+	                            testData.put("xDrip_sensor_confidence", calRecord.sensor_confidence);
+	                            testData.put("xDrip_raw_timestamp", calRecord.raw_timestamp);
+                            }               
                             testData.put("sysTime", format.format(meterRecord.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "mbg").append("sysTime", format.format(meterRecord.timestamp));
                             dexcomData.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);
@@ -367,15 +375,8 @@ public class NightscoutUploader {
                                 testData.put("intercept", (long) ((calRecord.intercept * -1000) / (calRecord.slope * 1000)));
                                 testData.put("scale", 1);
                             }
-                            if(nightWatchproMode) {
-	                            testData.put("xDrip_slope", calRecord.slope);
-	                            testData.put("xDrip_intercept", calRecord.intercept);
-	                            testData.put("xDrip_estimate_raw_at_time_of_calibration", calRecord.estimate_raw_at_time_of_calibration);
-	                            testData.put("xDrip_slope_confidence", calRecord.slope_confidence);
-	                            testData.put("xDrip_sensor_confidence", calRecord.sensor_confidence);
-	                            testData.put("xDrip_raw_timestamp", calRecord.raw_timestamp);
-	                            testData.put("type", "cal");
-                            }
+
+                            testData.put("type", "cal");
                             
                             testData.put("sysTime", format.format(calRecord.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "cal").append("sysTime", format.format(calRecord.timestamp));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -305,7 +305,12 @@ public class NightscoutUploader {
                             testData.put("unfiltered", record.usedRaw() * 1000);
                             testData.put("rssi", 100);
                             testData.put("noise", record.noiseValue());
-                            dexcomData.insert(testData, WriteConcern.UNACKNOWLEDGED);
+                            testData.put("xDrip_raw", record.raw_data);
+                            testData.put("xDrip_filtered", record.filtered_data);
+
+                            testData.put("sysTime", format.format(record.timestamp));
+                            BasicDBObject query = new BasicDBObject("type", "sgv").append("sysTime", format.format(record.timestamp));
+                            dexcomData.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);
                         }
 
                         Log.i(TAG, "The number of MBG records being sent to MongoDB is " + meterRecords.size());
@@ -317,7 +322,13 @@ public class NightscoutUploader {
                             testData.put("date", meterRecord.timestamp);
                             testData.put("dateString", format.format(meterRecord.timestamp));
                             testData.put("mbg", meterRecord.bg);
+                            testData.put("xDrip_slope", meterRecord.slope);
+                            testData.put("xDrip_intercept", meterRecord.intercept);
                             dexcomData.insert(testData, WriteConcern.UNACKNOWLEDGED);
+                            
+                            testData.put("sysTime", format.format(meterRecord.timestamp));
+                            BasicDBObject query = new BasicDBObject("type", "mbg").append("sysTime", format.format(meterRecord.timestamp));
+                            dexcomData.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);
                         }
 
                         for (Calibration calRecord : calRecords) {
@@ -336,7 +347,10 @@ public class NightscoutUploader {
                                 testData.put("scale", 1);
                             }
                             testData.put("type", "cal");
-                            dexcomData.insert(testData, WriteConcern.UNACKNOWLEDGED);
+                            
+                            testData.put("sysTime", format.format(calRecord.timestamp));
+                            BasicDBObject query = new BasicDBObject("type", "cal").append("sysTime", format.format(calRecord.timestamp));
+                            dexcomData.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);
                         }
 
                         // TODO: quick port from original code, revisit before release

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -204,7 +204,7 @@ public class NightscoutUploader {
             json.put("device", "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel"));
             json.put("date", record.timestamp);
             json.put("dateString", format.format(record.timestamp));
-            json.put("sgv", (int)record.calculated_value);
+            json.put("sgv", Math.round(record.calculated_value));
             json.put("direction", record.slopeName());
             json.put("type", "sgv");
             json.put("filtered", record.ageAdjustedFiltered() * 1000);
@@ -215,6 +215,7 @@ public class NightscoutUploader {
             json.put("xDrip_filtered", record.filtered_data);
             json.put("xDrip_calculated_value", record.calculated_value);
             json.put("xDrip_age_adjusted_raw_value", record.age_adjusted_raw_value);
+            json.put("xDrip_calculated_current_slope", record.currentSlope());
             json.put("sysTime", format.format(record.timestamp));
             array.put(json);
         }
@@ -226,7 +227,7 @@ public class NightscoutUploader {
             json.put("device", "xDrip-"+prefs.getString("dex_collection_method", "BluetoothWixel"));
             json.put("date", record.timestamp);
             json.put("dateString", format.format(record.timestamp));
-            json.put("sgv", (int)record.calculated_value);
+            json.put("sgv", Math.round(record.calculated_value));
             json.put("direction", record.slopeName());
             return RequestBody.create(MediaType.parse("application/json"), json.toString());
         }
@@ -324,6 +325,7 @@ public class NightscoutUploader {
                             testData.put("xDrip_raw", record.raw_data);
                             testData.put("xDrip_filtered", record.filtered_data);
                             testData.put("xDrip_calculated_value", record.calculated_value);
+                            testData.put("xDrip_calculated_current_slope", record.currentSlope());
                             testData.put("xDrip_age_adjusted_raw_value", record.age_adjusted_raw_value);
                             
                             testData.put("sysTime", format.format(record.timestamp));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -324,7 +324,6 @@ public class NightscoutUploader {
                             testData.put("mbg", meterRecord.bg);
                             testData.put("xDrip_slope", meterRecord.slope);
                             testData.put("xDrip_intercept", meterRecord.intercept);
-                            dexcomData.insert(testData, WriteConcern.UNACKNOWLEDGED);
                             
                             testData.put("sysTime", format.format(meterRecord.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "mbg").append("sysTime", format.format(meterRecord.timestamp));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -324,6 +324,7 @@ public class NightscoutUploader {
                             testData.put("mbg", meterRecord.bg);
                             testData.put("xDrip_slope", meterRecord.slope);
                             testData.put("xDrip_intercept", meterRecord.intercept);
+                            testData.put("xDrip_estimate_raw_at_time_of_calibration", meterRecord.estimate_raw_at_time_of_calibration);
                             
                             testData.put("sysTime", format.format(meterRecord.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "mbg").append("sysTime", format.format(meterRecord.timestamp));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -196,6 +196,9 @@ public class NightscoutUploader {
         }
 
         private void populateV1APIBGEntry(JSONArray array, BgReading record) throws Exception {
+            
+            Log.e(TAG, "populateV1APIBGEntry preparing bg with data " + record.timestamp);
+            
             JSONObject json = new JSONObject();
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
             format.setTimeZone(TimeZone.getDefault());
@@ -209,6 +212,10 @@ public class NightscoutUploader {
             json.put("unfiltered", record.usedRaw() * 1000);
             json.put("rssi", 100);
             json.put("noise", record.noiseValue());
+            json.put("xDrip_raw", record.raw_data);
+            json.put("xDrip_filtered", record.filtered_data);
+            json.put("xDrip_calculated_value", record.calculated_value);
+            json.put("xDrip_age_adjusted_raw_value", record.age_adjusted_raw_value);
             array.put(json);
         }
 
@@ -233,6 +240,12 @@ public class NightscoutUploader {
             json.put("date", record.timestamp);
             json.put("dateString", format.format(record.timestamp));
             json.put("mbg", record.bg);
+            json.put("xDrip_slope", record.slope);
+            json.put("xDrip_intercept", record.intercept);
+            json.put("xDrip_estimate_raw_at_time_of_calibration", record.estimate_raw_at_time_of_calibration);
+            json.put("xDrip_slope_confidence", record.slope_confidence);
+            json.put("xDrip_sensor_confidence", record.sensor_confidence);
+            json.put("xDrip_raw_timestamp", record.raw_timestamp);
             array.put(json);
         }
 
@@ -291,9 +304,10 @@ public class NightscoutUploader {
                     DBCollection dexcomData = db.getCollection(collectionName.trim());
 
                     try {
-                        Log.i(TAG, "The number of EGV records being sent to MongoDB is " + glucoseDataSets.size());
+                        Log.e(TAG, "The number of EGV records being sent to MongoDB is " + glucoseDataSets.size());
                         for (BgReading record : glucoseDataSets) {
                             // make db object
+                            Log.e(TAG, "uploading bg with data " + record.timestamp);
                             BasicDBObject testData = new BasicDBObject();
                             testData.put("device", "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel"));
                             testData.put("date", record.timestamp);
@@ -307,6 +321,9 @@ public class NightscoutUploader {
                             testData.put("noise", record.noiseValue());
                             testData.put("xDrip_raw", record.raw_data);
                             testData.put("xDrip_filtered", record.filtered_data);
+                            testData.put("xDrip_calculated_value", record.calculated_value);
+                            testData.put("xDrip_age_adjusted_raw_value", record.age_adjusted_raw_value);
+                            
 
                             testData.put("sysTime", format.format(record.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "sgv").append("sysTime", format.format(record.timestamp));
@@ -322,12 +339,6 @@ public class NightscoutUploader {
                             testData.put("date", meterRecord.timestamp);
                             testData.put("dateString", format.format(meterRecord.timestamp));
                             testData.put("mbg", meterRecord.bg);
-                            testData.put("xDrip_slope", meterRecord.slope);
-                            testData.put("xDrip_intercept", meterRecord.intercept);
-                            testData.put("xDrip_estimate_raw_at_time_of_calibration", meterRecord.estimate_raw_at_time_of_calibration);
-                            testData.put("xDrip_slope_confidence", meterRecord.slope_confidence);
-                            testData.put("xDrip_sensor_confidence", meterRecord.sensor_confidence);
-                            testData.put("xDrip_raw_timestamp", meterRecord.raw_timestamp);
                             testData.put("sysTime", format.format(meterRecord.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "mbg").append("sysTime", format.format(meterRecord.timestamp));
                             dexcomData.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);
@@ -348,7 +359,14 @@ public class NightscoutUploader {
                                 testData.put("intercept", (long) ((calRecord.intercept * -1000) / (calRecord.slope * 1000)));
                                 testData.put("scale", 1);
                             }
+                            testData.put("xDrip_slope", calRecord.slope);
+                            testData.put("xDrip_intercept", calRecord.intercept);
+                            testData.put("xDrip_estimate_raw_at_time_of_calibration", calRecord.estimate_raw_at_time_of_calibration);
+                            testData.put("xDrip_slope_confidence", calRecord.slope_confidence);
+                            testData.put("xDrip_sensor_confidence", calRecord.sensor_confidence);
+                            testData.put("xDrip_raw_timestamp", calRecord.raw_timestamp);
                             testData.put("type", "cal");
+
                             
                             testData.put("sysTime", format.format(calRecord.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "cal").append("sysTime", format.format(calRecord.timestamp));

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -325,7 +325,9 @@ public class NightscoutUploader {
                             testData.put("xDrip_slope", meterRecord.slope);
                             testData.put("xDrip_intercept", meterRecord.intercept);
                             testData.put("xDrip_estimate_raw_at_time_of_calibration", meterRecord.estimate_raw_at_time_of_calibration);
-                            
+                            testData.put("xDrip_slope_confidence", meterRecord.slope_confidence);
+                            testData.put("xDrip_sensor_confidence", meterRecord.sensor_confidence);
+                            testData.put("xDrip_raw_timestamp", meterRecord.raw_timestamp);
                             testData.put("sysTime", format.format(meterRecord.timestamp));
                             BasicDBObject query = new BasicDBObject("type", "mbg").append("sysTime", format.format(meterRecord.timestamp));
                             dexcomData.update(query, testData, true, false,  WriteConcern.UNACKNOWLEDGED);

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -51,9 +51,9 @@
             android:summary="Disable the warning for low transmitter battery state on the home screen. (Only relevant for DIY receivers.)"
             android:defaultValue="false" />
         <CheckBoxPreference
-            android:key="nightwatchpro_upload_mode"
-            android:title="NightwatchPro upload mode"
-            android:summary="Upload more fields needed for optimum NightwatchPro functioning"
+            android:key="xDripViewer_upload_mode"
+            android:title="xDripViewer upload mode"
+            android:summary="Upload more fields needed for optimum xDripViewer functioning"
             android:defaultValue="false" />
         <Preference
             android:title="View Recent Errors/Warnings"

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -50,6 +50,11 @@
             android:title="Disable Battery Warning"
             android:summary="Disable the warning for low transmitter battery state on the home screen. (Only relevant for DIY receivers.)"
             android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="nightwatchpro_upload_mode"
+            android:title="NightwatchPro upload mode"
+            android:summary="Upload more fields needed for optimum NightwatchPro functioning"
+            android:defaultValue="false" />
         <Preference
             android:title="View Recent Errors/Warnings"
             android:key="recent_errors">


### PR DESCRIPTION
This PR fixes a lot of issues on send queue that we have talked about in the last month:

1) Use Upserts.
2) Correct use of wake lock.
3) Keep sending until there is nothing more to send (or error).
4) More efficient sending. (bigger number of objects being uploaded).
5) delete objects after using them in order not to make the db grow for ever.
6) upload more needed fields.
7) keep sending while there is work to do.

I have checked it with both mongo and NS and it seems that uploading 300 objects takes around 10-15 seconds on mongo and ~25 seconds on NS rest api.
On the other hand uploading 3 objects is much faster on the NS REST api (0.7 second compared to 4-5 seconds on mongo).
(There is a big fluctuation on measured times).

Checked this by uploading 500 objects every time. Worked well on mongo, but caused Azure to collapse (not sure it was realy this...).

I'll keep checking this with normal load for a few more days.
