### PR TITLE
Make sure that in the case that no good calibration exists, reasonable…

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -393,7 +393,7 @@ public class Calibration extends Model {
                 .execute();
     }
 
-    public static void calculate_w_l_s() {
+    private static void calculate_w_l_s() {
         if (Sensor.isActive()) {
             double l = 0;
             double m = 0;
@@ -407,6 +407,7 @@ public class Calibration extends Model {
                 calibration.slope = 1;
                 calibration.intercept = calibration.bg - (calibration.raw_value * calibration.slope);
                 calibration.save();
+                CalibrationRequest.createOffset(calibration.bg, 25);
             } else {
                 for (Calibration calibration : calibrations) {
                     w = calibration.calculateWeight();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -402,7 +402,7 @@ public class Calibration extends Model {
             double q = 0;
             double w;
             List<Calibration> calibrations = allForSensorInLastFourDays(); //5 days was a bit much, dropped this to 4
-            if (calibrations.size() == 1) {
+            if (calibrations.size() <= 1) {
                 Calibration calibration = Calibration.last();
                 calibration.slope = 1;
                 calibration.intercept = calibration.bg - (calibration.raw_value * calibration.slope);


### PR DESCRIPTION
… data will be used for slope and intercept.

Seems that if a calibration exists but with slope_confidence == 0
the function allForSensorInLastFourDays() might return with a list with size 0.
This will lead it to reaching the line 
 double d = (l \* n) - (m \* m);
and d will be 0.
As a result, 
calibration.intercept = ((n \* p) - (m \* q)) / d;
will be divided by 0, which means bad things later...

By mistake, pushed it already at master, but please review and let me know if this seems a good fix.
