### PR TITLE
slope and intercept transformation for NightScout

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSendQueue.java
@@ -120,12 +120,12 @@ public class BgSendQueue extends Model {
                         intercept= cal.first_intercept;
                         scale =  cal.first_scale;
                     } else {
-                        slope = cal.slope * 1000;
-                        intercept=  (cal.intercept * -1000) / (cal.slope * 1000);
+                        slope = 1000/cal.slope;
+                        intercept=  (cal.intercept * -1000) / (cal.slope);
                         scale = 1;
                     }
-                    unfiltered= bgReading.usedRaw();
-                    filtered = bgReading.ageAdjustedFiltered();
+                    unfiltered= bgReading.usedRaw()*1000;
+                    filtered = bgReading.ageAdjustedFiltered()*1000;
                 }
                 //raw logic from https://github.com/nightscout/cgm-remote-monitor/blob/master/lib/plugins/rawbg.js#L59
                 if (slope != 0 && intercept != 0 && scale != 0) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -237,6 +237,10 @@ public class NightscoutUploader {
         }
 
         private void populateV1APICalibrationEntry(JSONArray array, Calibration record) throws Exception {
+
+            //do not upload undefined slopes
+            if(record.slope == 0d) return;
+
             JSONObject json = new JSONObject();
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
             format.setTimeZone(TimeZone.getDefault());
@@ -245,12 +249,12 @@ public class NightscoutUploader {
             json.put("date", record.timestamp);
             json.put("dateString", format.format(record.timestamp));
             if(record.check_in) {
-                json.put("slope", (long) (record.first_slope));
-                json.put("intercept", (long) ((record.first_intercept)));
+                json.put("slope", (record.first_slope));
+                json.put("intercept", ((record.first_intercept)));
                 json.put("scale", record.first_scale);
             } else {
-                json.put("slope", (long) (record.slope * 1000));
-                json.put("intercept", (long) ((record.intercept * -1000) / (record.slope * 1000)));
+                json.put("slope", (1000/record.slope));
+                json.put("intercept", ((record.intercept * -1000) / (record.slope)));
                 json.put("scale", 1);
             }
             array.put(json);
@@ -321,18 +325,20 @@ public class NightscoutUploader {
                         }
 
                         for (Calibration calRecord : calRecords) {
+                            //do not upload undefined slopes
+                            if(calRecord.slope == 0d) break;
                             // make db object
                             BasicDBObject testData = new BasicDBObject();
                             testData.put("device", "xDrip-" + prefs.getString("dex_collection_method", "BluetoothWixel"));
                             testData.put("date", calRecord.timestamp);
                             testData.put("dateString", format.format(calRecord.timestamp));
                             if (calRecord.check_in) {
-                                testData.put("slope", (long) (calRecord.first_slope));
-                                testData.put("intercept", (long) ((calRecord.first_intercept)));
+                                testData.put("slope", (calRecord.first_slope));
+                                testData.put("intercept", ((calRecord.first_intercept)));
                                 testData.put("scale", calRecord.first_scale);
                             } else {
-                                testData.put("slope", (long) (calRecord.slope * 1000));
-                                testData.put("intercept", (long) ((calRecord.intercept * -1000) / (calRecord.slope * 1000)));
+                                testData.put("slope",  (1000/calRecord.slope));
+                                testData.put("intercept", ((calRecord.intercept * -1000) / (calRecord.slope)));
                                 testData.put("scale", 1);
                             }
                             testData.put("type", "cal");


### PR DESCRIPTION
**1) Calculation of Slope and Intercept for NightScout**

In xDrip(wixel) we calculate the values in the form: `raw*slope + intercept`
NS (and dexcom?) calculate the values in the form: `(raw - intercept)/slope`

Also raw values are 1000 times of what we have in xDrip.

You can rearrange the xDrip formula like this:

`s*r + i = (1000*r - (i * -1000/s) ) / (1000/s)`
(Test this with wolfram-alpha: http://www.wolframalpha.com/share/clip?f=d41d8cd98f00b204e9800998ecf8427eh82hpg790s)

This is the same as `(NS_raw - NS_intercept) / NS_slope` if:
- NS_raw = 1000*r
- NS_intercept = (i \* -1000/s)
- NS_slope = (1000/s)

**2) Upload Slope and Intercept with higher precision**
NightScout can handle float values. -> higher precision
