### PR TITLE
avoid a crash when preparing graph and using comma as a decimal separator

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -506,12 +506,10 @@ public class BgReading extends Model implements ShareUploadableBg{
                 .execute();
     }
 
-    public static List<BgReading> latestForGraph(int number, double startTime) {
-        DecimalFormat df = new DecimalFormat("#");
-        df.setMaximumFractionDigits(1);
+    public static List<BgReading> latestForGraph(int number, long startTime) {
         return new Select()
                 .from(BgReading.class)
-                .where("timestamp >= " + df.format(startTime))
+                .where("timestamp >= " + (startTime >= 0 ? startTime : 0))
                 .where("calculated_value != 0")
                 .where("raw_data != 0")
                 .orderBy("timestamp desc")
@@ -520,7 +518,7 @@ public class BgReading extends Model implements ShareUploadableBg{
     }
 
     public static List<BgReading> last30Minutes() {
-        double timestamp = (new Date().getTime()) - (60000 * 30);
+        long timestamp = (new Date().getTime()) - (60000 * 30);
         return new Select()
                 .from(BgReading.class)
                 .where("timestamp >= " + timestamp)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -24,10 +24,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.internal.bind.DateTypeAdapter;
 
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+import java.text.NumberFormat;
+import java.util.*;
 
 /**
  * Created by stephenblack on 10/29/14.
@@ -638,7 +636,8 @@ public class Calibration extends Model {
     }
 
     public static List<Calibration> latestForGraph(int number, double startTime) {
-        DecimalFormat df = new DecimalFormat("#");
+        DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+        df.applyPattern("#");
         df.setMaximumFractionDigits(1);
         return new Select()
                 .from(Calibration.class)

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Calibration.java
@@ -635,13 +635,10 @@ public class Calibration extends Model {
                 .execute();
     }
 
-    public static List<Calibration> latestForGraph(int number, double startTime) {
-        DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(Locale.US);
-        df.applyPattern("#");
-        df.setMaximumFractionDigits(1);
+    public static List<Calibration> latestForGraph(int number, long startTime) {
         return new Select()
                 .from(Calibration.class)
-                .where("timestamp >= " + df.format(startTime))
+                .where("timestamp >= " + ((startTime >= 0) ? startTime : 0))
                 .orderBy("timestamp desc")
                 .limit(number)
                 .execute();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -38,7 +38,7 @@ import lecho.lib.hellocharts.view.Chart;
 public class BgGraphBuilder {
     public static final int FUZZER = (1000 * 30 * 5);
     public double  end_time = (new Date().getTime() + (60000 * 10)) / FUZZER;
-    public double  start_time = end_time - ((60000 * 60 * 24)) / FUZZER;
+    public double  start_time = Math.floor(Math.max(end_time - ((60000 * 60 * 24)) / FUZZER, 0));
     public Context context;
     public SharedPreferences prefs;
     public double highMark;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -37,8 +37,8 @@ import lecho.lib.hellocharts.view.Chart;
  */
 public class BgGraphBuilder {
     public static final int FUZZER = (1000 * 30 * 5);
-    public double  end_time = (new Date().getTime() + (60000 * 10)) / FUZZER;
-    public double  start_time = Math.floor(Math.max(end_time - ((60000 * 60 * 24)) / FUZZER, 0));
+    public long end_time = (new Date().getTime() + (60000 * 10)) / FUZZER;
+    public long start_time = end_time - ((60000 * 60 * 24)) / FUZZER;
     public Context context;
     public SharedPreferences prefs;
     public double highMark;


### PR DESCRIPTION
This should fix this:

```
Fatal Exception: java.lang.RuntimeException: Unable to start receiver com.eveningoutpost.dexdrip.xDripWidget: android.database.sqlite.SQLiteException: near ",": syntax error (code 1): , while compiling: SELECT * FROM Calibration WHERE timestamp >= ,4 ORDER BY timestamp desc LIMIT 288
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:2649)
       at android.app.ActivityThread.access$1800(ActivityThread.java:154)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1398)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5294)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:904)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:699)
Caused by android.database.sqlite.SQLiteException: near ",": syntax error (code 1): , while compiling: SELECT * FROM Calibration WHERE timestamp >= ,4 ORDER BY timestamp desc LIMIT 288
       at android.database.sqlite.SQLiteConnection.nativePrepareStatement(SQLiteConnection.java)
       at android.database.sqlite.SQLiteConnection.acquirePreparedStatement(SQLiteConnection.java:891)
       at android.database.sqlite.SQLiteConnection.prepare(SQLiteConnection.java:502)
       at android.database.sqlite.SQLiteSession.prepare(SQLiteSession.java:588)
       at android.database.sqlite.SQLiteProgram.<init>(SQLiteProgram.java:58)
       at android.database.sqlite.SQLiteQuery.<init>(SQLiteQuery.java:37)
       at android.database.sqlite.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:44)
       at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1316)
       at android.database.sqlite.SQLiteDatabase.rawQuery(SQLiteDatabase.java:1255)
       at com.activeandroid.util.SQLiteUtils.rawQuery(Unknown Source)
       at com.activeandroid.query.From.execute(Unknown Source)
       at com.eveningoutpost.dexdrip.Models.Calibration.latestForGraph(Calibration.java:638)
       at com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder.<init>(BgGraphBuilder.java:55)
       at com.eveningoutpost.dexdrip.xDripWidget.displayCurrentInfo(xDripWidget.java:66)
       at com.eveningoutpost.dexdrip.xDripWidget.updateAppWidget(xDripWidget.java:60)
       at com.eveningoutpost.dexdrip.xDripWidget.onUpdate(xDripWidget.java:35)
       at android.appwidget.AppWidgetProvider.onReceive(AppWidgetProvider.java:66)
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:2642)
       at android.app.ActivityThread.access$1800(ActivityThread.java:154)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1398)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5294)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:904)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:699)
```

and the related crash:

```
Fatal Exception: java.lang.RuntimeException: Unable to start receiver com.eveningoutpost.dexdrip.xDripWidget: android.database.sqlite.SQLiteException: no such column: −84300000 (code 1): , while compiling: SELECT * FROM BgReadings WHERE timestamp >= −84300000 AND calculated_value != 0 AND raw_data != 0 ORDER BY timestamp desc LIMIT 288
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:2640)
       at android.app.ActivityThread.access$1600(ActivityThread.java:155)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1394)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5298)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:911)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:706)
Caused by android.database.sqlite.SQLiteException: no such column: −84300000 (code 1): , while compiling: SELECT * FROM BgReadings WHERE timestamp >= −84300000 AND calculated_value != 0 AND raw_data != 0 ORDER BY timestamp desc LIMIT 288
       at android.database.sqlite.SQLiteConnection.nativePrepareStatement(SQLiteConnection.java)
       at android.database.sqlite.SQLiteConnection.acquirePreparedStatement(SQLiteConnection.java:889)
       at android.database.sqlite.SQLiteConnection.prepare(SQLiteConnection.java:500)
       at android.database.sqlite.SQLiteSession.prepare(SQLiteSession.java:588)
       at android.database.sqlite.SQLiteProgram.<init>(SQLiteProgram.java:58)
       at android.database.sqlite.SQLiteQuery.<init>(SQLiteQuery.java:37)
       at android.database.sqlite.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:44)
       at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1316)
       at android.database.sqlite.SQLiteDatabase.rawQuery(SQLiteDatabase.java:1255)
       at com.activeandroid.util.SQLiteUtils.rawQuery(Unknown Source)
       at com.activeandroid.query.From.execute(Unknown Source)
       at com.eveningoutpost.dexdrip.Models.BgReading.latestForGraph(BgReading.java:512)
       at com.eveningoutpost.dexdrip.UtilityModels.BgGraphBuilder.<init>(BgGraphBuilder.java:54)
       at com.eveningoutpost.dexdrip.xDripWidget.displayCurrentInfo(xDripWidget.java:66)
       at com.eveningoutpost.dexdrip.xDripWidget.updateAppWidget(xDripWidget.java:60)
       at com.eveningoutpost.dexdrip.xDripWidget.onUpdate(xDripWidget.java:35)
       at android.appwidget.AppWidgetProvider.onReceive(AppWidgetProvider.java:66)
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:2633)
       at android.app.ActivityThread.access$1600(ActivityThread.java:155)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1394)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5298)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:911)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:706)
```
