### PR TITLE
don't crash and burn when making toasts for CSV/database exports

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -525,7 +525,16 @@ public class Home extends ActivityWithMenu {
           new AsyncTask<Void, Void, String>() {
                 @Override
                 protected String doInBackground(Void... params) {
-                    return DatabaseUtil.saveCSV(getBaseContext());
+                    int permissionCheck = ContextCompat.checkSelfPermission(Home.this,
+                            android.Manifest.permission.READ_EXTERNAL_STORAGE);
+                    if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
+                        ActivityCompat.requestPermissions(Home.this,
+                                new String[]{android.Manifest.permission.READ_EXTERNAL_STORAGE},
+                                0);
+                        return null;
+                    } else {
+                        return DatabaseUtil.saveCSV(getBaseContext());
+                    }
                 }
 
                 @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.format.DateFormat;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 import android.widget.Toast;
@@ -31,9 +33,18 @@ import static com.eveningoutpost.dexdrip.utils.FileUtils.*;
  */
 public class DatabaseUtil {
 
-    public static final String TAG = DatabaseUtil.class.getSimpleName();
-    public static final int BUFFER_SIZE =  2048;
+    private static final String TAG = DatabaseUtil.class.getSimpleName();
+    private static final int BUFFER_SIZE =  2048;
 
+    private static void toastText(final Context context, final String text) {
+        Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(context, text, Toast.LENGTH_LONG).show();
+            }
+        });
+    }
 
     public static String saveSql(Context context) {
 
@@ -75,17 +86,17 @@ public class DatabaseUtil {
                         zipOutputStream.write(buffer, 0, count);
                     }
                 } else {
-                    Toast.makeText(context, "Problem: No current DB found!", Toast.LENGTH_LONG).show();
+                    toastText(context, "Problem: No current DB found!");
                     Log.d(TAG, "Problem: No current DB found");
                 }
             } else {
-                Toast.makeText(context, "SD card not writable!", Toast.LENGTH_LONG).show();
+                toastText(context, "SD card not writable!");
                 Log.d(TAG, "SD card not writable!");
                 zipFilename = null;
             }
 
         } catch (IOException e) {
-            Toast.makeText(context, "SD card not writable!", Toast.LENGTH_LONG).show();
+            toastText(context, "SD card not writable!");
             Log.e(TAG, "Exception while writing DB", e);
             zipFilename = null;
         } finally {
@@ -102,7 +113,6 @@ public class DatabaseUtil {
         }
         return zipFilename;
     }
-
 
     public static String saveSqlUnzipped(Context context) {
 
@@ -137,16 +147,16 @@ public class DatabaseUtil {
                     dst = destStream.getChannel();
                     dst.transferFrom(src, 0, src.size());
                 } else {
-                    Toast.makeText(context, "Problem: No current DB found!", Toast.LENGTH_LONG).show();
+                    toastText(context, "Problem: No current DB found!");
                     Log.d(TAG, "Problem: No current DB found");
                 }
             } else {
-                Toast.makeText(context, "SD card not writable!", Toast.LENGTH_LONG).show();
+                toastText(context, "SD card not writable!");
                 Log.d(TAG, "SD card not writable!");
             }
 
         } catch (IOException e) {
-            Toast.makeText(context, "SD card not writable!", Toast.LENGTH_LONG).show();
+            toastText(context, "SD card not writable!");
             Log.e(TAG, "Exception while writing DB", e);
         } finally {
             if (src != null) try {
@@ -237,12 +247,12 @@ public class DatabaseUtil {
 
 
             } else {
-                Toast.makeText(context, "SD card not writable!", Toast.LENGTH_LONG).show();
+                toastText(context, "SD card not writable!");
                 Log.d(TAG, "SD card not writable!");
             }
 
         } catch (IOException e) {
-            Toast.makeText(context, "SD card not writable!", Toast.LENGTH_LONG).show();
+            toastText(context, "SD card not writable!");
             Log.e(TAG, "Exception while writing DB", e);
         } finally {
             if (printStream != null) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/DatabaseUtil.java
@@ -35,9 +35,9 @@ public class DatabaseUtil {
 
     private static final String TAG = DatabaseUtil.class.getSimpleName();
     private static final int BUFFER_SIZE =  2048;
+    private static final Handler handler = new Handler(Looper.getMainLooper());
 
     private static void toastText(final Context context, final String text) {
-        Handler handler = new Handler(Looper.getMainLooper());
         handler.post(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
A bigger problem is that none of the Toasts around errors will actually work (they will crash the app instead).  Should probably be fixed in another PR.
