### PR TITLE
set a vibrate pattern that will never vibrate

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -267,7 +267,7 @@ public class AlertPlayer {
         } else {
             // In order to still show on all android wear watches, either a sound or a vibrate pattern
             // seems to be needed. This pattern basically does not vibrate:
-            builder.setVibrate(new long[]{alert.getNextAlertTime(ctx) + 60000, 1});
+            builder.setVibrate(new long[]{1, 0});
         }
         NotificationManager mNotifyMgr = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
         mNotifyMgr.cancel(Notifications.exportAlertNotificationId);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/AlertPlayer.java
@@ -264,6 +264,10 @@ public class AlertPlayer {
         }
         if (profile != ALERT_PROFILE_SILENT && alert.vibrate) {
             builder.setVibrate(Notifications.vibratePattern);
+        } else {
+            // In order to still show on all android wear watches, either a sound or a vibrate pattern
+            // seems to be needed. This pattern basically does not vibrate:
+            builder.setVibrate(new long[]{alert.getNextAlertTime(ctx) + 60000, 1});
         }
         NotificationManager mNotifyMgr = (NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
         mNotifyMgr.cancel(Notifications.exportAlertNotificationId);


### PR DESCRIPTION
_After an OS-Update, Notifications only show on my watch when they either vibrate or a sound is set. In most cases we don't set no sound as we play it separately. Setting the priority to maximum for the notification won't help either._

This change will guarantee that a vibrate pattern is set.
In the case the user doesn't want vibration, the waiting period until first vibration is set to one minute longer that the reraise period. In practice this means no vibration at all - but notifications still come through.
