### PR TITLE
Calibration graph cleanup

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
@@ -1,5 +1,6 @@
 package com.eveningoutpost.dexdrip;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.widget.TextView;
@@ -72,12 +73,14 @@ public class CalibrationGraph extends ActivityWithMenu {
 
             //calibration values
             List<Calibration> calibrations = Calibration.allForSensor();
+            Line greyLine = getCalibrationsLine(calibrations, Color.parseColor("#66FFFFFF"));
+            calibrations = Calibration.allForSensorInLastFourDays();
             Line blueLine = getCalibrationsLine(calibrations, ChartUtils.COLOR_BLUE);
 
             //add lines in order
-            lines.add(calibrationLine);
+            lines.add(greyLine);
             lines.add(blueLine);
-
+            lines.add(calibrationLine);
 
         }
         Axis axisX = new Axis();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/CalibrationGraph.java
@@ -1,6 +1,7 @@
 package com.eveningoutpost.dexdrip;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.widget.TextView;
 
 import com.eveningoutpost.dexdrip.Models.Calibration;
@@ -22,7 +23,7 @@ import lecho.lib.hellocharts.view.LineChartView;
 
 public class CalibrationGraph extends ActivityWithMenu {
     public static String menu_name = "Calibration Graph";
-   private LineChartView chart;
+    private LineChartView chart;
     private LineChartData data;
     public double  start_x = 50;
     public double  end_x = 300;
@@ -49,7 +50,51 @@ public class CalibrationGraph extends ActivityWithMenu {
 
     public void setupCharts() {
         chart = (LineChartView) findViewById(R.id.chart);
-        List<Calibration> calibrations = Calibration.allForSensor();
+        List<Line> lines = new ArrayList<Line>();
+
+        Calibration calibration = Calibration.last();
+        if(calibration != null) {
+            //set header
+            DecimalFormat df = new DecimalFormat("#");
+            df.setMaximumFractionDigits(2);
+            df.setMinimumFractionDigits(2);
+            String Header = "slope = " + df.format(calibration.slope) + " intercept = " + df.format(calibration.intercept);
+            GraphHeader.setText(Header);
+
+            //red line
+            List<PointValue> lineValues = new ArrayList<PointValue>();
+            lineValues.add(new PointValue((float) start_x, (float) (start_x * calibration.slope + calibration.intercept)));
+            lineValues.add(new PointValue((float) end_x, (float) (end_x * calibration.slope + calibration.intercept)));
+            Line calibrationLine = new Line(lineValues);
+            calibrationLine.setColor(ChartUtils.COLOR_RED);
+            calibrationLine.setHasLines(true);
+            calibrationLine.setHasPoints(false);
+
+            //calibration values
+            List<Calibration> calibrations = Calibration.allForSensor();
+            Line blueLine = getCalibrationsLine(calibrations, ChartUtils.COLOR_BLUE);
+
+            //add lines in order
+            lines.add(calibrationLine);
+            lines.add(blueLine);
+
+
+        }
+        Axis axisX = new Axis();
+        Axis axisY = new Axis().setHasLines(true);
+        axisX.setName("Raw Value");
+        axisY.setName("BG");
+
+
+        data = new LineChartData(lines);
+        data.setAxisXBottom(axisX);
+        data.setAxisYLeft(axisY);
+        chart.setLineChartData(data);
+
+    }
+
+    @NonNull
+    public Line getCalibrationsLine(List<Calibration> calibrations, int color) {
         List<PointValue> values = new ArrayList<PointValue>();
         for (Calibration calibration : calibrations) {
             PointValue point = new PointValue((float)calibration.estimate_raw_at_time_of_calibration, (float)calibration.bg);
@@ -59,41 +104,11 @@ public class CalibrationGraph extends ActivityWithMenu {
         }
 
         Line line = new Line(values);
-        line.setColor(ChartUtils.COLOR_BLUE);
+        line.setColor(color);
         line.setHasLines(false);
         line.setPointRadius(4);
         line.setHasPoints(true);
         line.setHasLabels(true);
-
-        Calibration calibration = Calibration.last();
-        List<PointValue> lineValues = new ArrayList<PointValue>();
-        if(calibration != null) {
-            lineValues.add(new PointValue((float) start_x, (float) (start_x * calibration.slope + calibration.intercept)));
-            lineValues.add(new PointValue((float) end_x, (float) (end_x * calibration.slope + calibration.intercept)));
-
-            DecimalFormat df = new DecimalFormat("#");
-            df.setMaximumFractionDigits(2);
-            df.setMinimumFractionDigits(2);
-            String Header = "slope = " + df.format(calibration.slope) + " intercept = " + df.format(calibration.intercept);
-            GraphHeader.setText(Header);
-        }
-        Line calibrationLine = new Line(lineValues);
-        calibrationLine.setColor(ChartUtils.COLOR_RED);
-        calibrationLine.setHasLines(true);
-        calibrationLine.setHasPoints(false);
-        Axis axisX = new Axis();
-        Axis axisY = new Axis().setHasLines(true);
-        axisX.setName("Raw Value");
-        axisY.setName("BG");
-
-         List<Line> lines = new ArrayList<Line>();
-        lines.add(line);
-        lines.add(calibrationLine);
-
-        data = new LineChartData(lines);
-        data.setAxisXBottom(axisX);
-        data.setAxisYLeft(axisY);
-        chart.setLineChartData(data);
-
+        return line;
     }
 }


### PR DESCRIPTION
For sensors that are in longer, quite a number of calibrations can accumulate and the calibration graph gets quite unreadable because all the information is overlapping:
![How the CalibrationGraph was](http://up.picr.de/24238238er.png)

Now calibrations that are older than 4 days are greyed out:
![How the CalibrationGraph will look like](http://up.picr.de/24238239vf.png)
