### PR TITLE
Proguard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,11 @@ android {
         multiDexEnabled true
     }
     buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'),
+                    'proguard-rules.pro'
+        }
     }
 }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,3 +20,11 @@
 -keep class retrofit.** { *; }
 -keepattributes Signature
 -keepattributes Exceptions
+-dontwarn com.**
+-dontwarn net.**
+-dontwarn okio.**
+-dontwarn org.**
+-dontwarn rx.**
+
+
+-dontobfuscate


### PR DESCRIPTION
This is the very naive approach adding nowarns for anything.
The retrofit rules already were in place but I couldn't test them.

So far I successfully tested it for:
- Wixel input methods
- Alarms
- Widgets (home and lockscreen)
- Android wear / smartwatch
- Direct Mongo upload
- Speak Readings
- Most settings
- Statistics

It would be good if this could be tested for the Share-Receiver, Pebble and Share and Nightscout upload.
