### PR TITLE
Add ability to set Transparent High/Low lines.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -200,22 +200,24 @@ public class BgGraphBuilder {
         return highLine;
     }
 
-    public Line lowLine(){ return lowLine(true);}
+    public Line lowLine(){ return lowLine(true, false);}
 
-    public Line lowLine(boolean show) {
+    public Line lowLine(boolean show, boolean line_only) {
         List<PointValue> lowLineValues = new ArrayList<PointValue>();
         lowLineValues.add(new PointValue((float)start_time, (float)lowMark));
         lowLineValues.add(new PointValue((float) end_time, (float) lowMark));
         Line lowLine = new Line(lowLineValues);
         lowLine.setHasPoints(false);
-        lowLine.setAreaTransparency(50);
+        if(!line_only) {
+            lowLine.setAreaTransparency(50);
+            lowLine.setFilled(true);
+        }
+        lowLine.setStrokeWidth(1);
         if(show){
             lowLine.setColor(Color.parseColor("#C30909"));
         } else {
             lowLine.setColor(Color.TRANSPARENT);
         }
-        lowLine.setStrokeWidth(1);
-        lowLine.setFilled(true);
         return lowLine;
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -60,6 +60,8 @@ public class BgGraphBuilder {
     private List<PointValue> lowValues = new ArrayList<PointValue>();
     private List<PointValue> rawInterpretedValues = new ArrayList<PointValue>();
     private List<PointValue> calibrationValues = new ArrayList<PointValue>();
+    static final boolean LINE_VISIBLE = true;
+    static final boolean FILL_UNDER_LINE = false;
     public Viewport viewport;
 
 
@@ -183,7 +185,7 @@ public class BgGraphBuilder {
         }
     }
 
-    public Line highLine(){ return highLine(true);}
+    public Line highLine(){ return highLine(LINE_VISIBLE);}
 
     public Line highLine(boolean show) {
         List<PointValue> highLineValues = new ArrayList<PointValue>();
@@ -200,7 +202,7 @@ public class BgGraphBuilder {
         return highLine;
     }
 
-    public Line lowLine(){ return lowLine(true, false);}
+    public Line lowLine(){ return lowLine(LINE_VISIBLE, FILL_UNDER_LINE);}
 
     public Line lowLine(boolean show, boolean line_only) {
         List<PointValue> lowLineValues = new ArrayList<PointValue>();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -183,25 +183,37 @@ public class BgGraphBuilder {
         }
     }
 
-    public Line highLine() {
+    public Line highLine(){ return highLine(true);}
+
+    public Line highLine(boolean show) {
         List<PointValue> highLineValues = new ArrayList<PointValue>();
         highLineValues.add(new PointValue((float) start_time, (float) highMark));
         highLineValues.add(new PointValue((float) end_time, (float) highMark));
         Line highLine = new Line(highLineValues);
         highLine.setHasPoints(false);
         highLine.setStrokeWidth(1);
-        highLine.setColor(ChartUtils.COLOR_ORANGE);
+        if(show) {
+            highLine.setColor(ChartUtils.COLOR_ORANGE);
+        } else {
+            highLine.setColor(Color.TRANSPARENT);
+        }
         return highLine;
     }
 
-    public Line lowLine() {
+    public Line lowLine(){ return lowLine(true);}
+
+    public Line lowLine(boolean show) {
         List<PointValue> lowLineValues = new ArrayList<PointValue>();
         lowLineValues.add(new PointValue((float)start_time, (float)lowMark));
-        lowLineValues.add(new PointValue((float)end_time, (float)lowMark));
+        lowLineValues.add(new PointValue((float) end_time, (float) lowMark));
         Line lowLine = new Line(lowLineValues);
         lowLine.setHasPoints(false);
         lowLine.setAreaTransparency(50);
-        lowLine.setColor(Color.parseColor("#C30909"));
+        if(show){
+            lowLine.setColor(Color.parseColor("#C30909"));
+        } else {
+            lowLine.setColor(Color.TRANSPARENT);
+        }
         lowLine.setStrokeWidth(1);
         lowLine.setFilled(true);
         return lowLine;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
@@ -38,6 +38,7 @@ public class BgSparklineBuilder {
     private boolean showHighLine = false;
     private boolean showAxes = false;
     private boolean useSmallDots = true;
+    private boolean useTinyDots = false;
 
     public BgSparklineBuilder setStart(long start) {
         this.start = start / BgGraphBuilder.FUZZER;
@@ -100,10 +101,16 @@ public class BgSparklineBuilder {
         this.useSmallDots = useSmallDots;
         return this;
     }
+    public BgSparklineBuilder setTinyDots(boolean useTinyDots) {
+        this.useTinyDots = useTinyDots;
+        return this;
+    }
 
     public BgSparklineBuilder setSmallDots() {
         return this.setSmallDots(true);
     }
+
+    public BgSparklineBuilder setTinyDots() { return this.setTinyDots(true); }
 
     public BgSparklineBuilder setBgGraphBuilder(BgGraphBuilder bgGraphBuilder) {
         this.bgGraphBuilder = bgGraphBuilder;
@@ -165,13 +172,17 @@ public class BgSparklineBuilder {
         lines.add(bgGraphBuilder.inRangeValuesLine());
         lines.add(bgGraphBuilder.lowValuesLine());
         lines.add(bgGraphBuilder.highValuesLine());
-        if (showLowLine)
-            lines.add(bgGraphBuilder.lowLine());
-        if (showHighLine)
-            lines.add(bgGraphBuilder.highLine());
+        //if (showLowLine)
+            lines.add(bgGraphBuilder.lowLine(showLowLine));
+        //if (showHighLine)
+            lines.add(bgGraphBuilder.highLine(showLowLine));
         if (useSmallDots) {
             for(Line line: lines)
                 line.setPointRadius(2);
+        }
+        if (useTinyDots) {
+            for(Line line: lines)
+                line.setPointRadius(1);
         }
         LineChartData lineData = new LineChartData(lines);
         if (showAxes) {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
@@ -172,10 +172,8 @@ public class BgSparklineBuilder {
         lines.add(bgGraphBuilder.inRangeValuesLine());
         lines.add(bgGraphBuilder.lowValuesLine());
         lines.add(bgGraphBuilder.highValuesLine());
-        //if (showLowLine)
-            lines.add(bgGraphBuilder.lowLine(showLowLine, true));
-        //if (showHighLine)
-            lines.add(bgGraphBuilder.highLine(showHighLine));
+        lines.add(bgGraphBuilder.lowLine(showLowLine, true));
+        lines.add(bgGraphBuilder.highLine(showHighLine));
         if (useSmallDots) {
             for(Line line: lines)
                 line.setPointRadius(2);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
@@ -173,9 +173,9 @@ public class BgSparklineBuilder {
         lines.add(bgGraphBuilder.lowValuesLine());
         lines.add(bgGraphBuilder.highValuesLine());
         //if (showLowLine)
-            lines.add(bgGraphBuilder.lowLine(showLowLine));
+            lines.add(bgGraphBuilder.lowLine(showLowLine, true));
         //if (showHighLine)
-            lines.add(bgGraphBuilder.highLine(showLowLine));
+            lines.add(bgGraphBuilder.highLine(showHighLine));
         if (useSmallDots) {
             for(Line line: lines)
                 line.setPointRadius(2);


### PR DESCRIPTION
Fixes case where BgGraphBuilder autoscales any graph that DOES NOT have
High/Low lines if they are not explicitly set on.  This is undesirable
when BgSparklineBuilder draws a trend for the Pebble.
- Added logic in highLine() and lowLine() to allow a boolean to be passed,
- while keeping the no parameter overload.  No parameter turns the lines
- ON by default.
- Added logic to BgSparkLineBuilder to send the value passed to
- setHighLine() and setLowLine() on to BgGraphBuilder.
