### PR TITLE
fix point size in preview chart

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -90,9 +90,9 @@ public class BgGraphBuilder {
         LineChartData previewLineData = new LineChartData(lineData());
         previewLineData.setAxisYLeft(yAxis());
         previewLineData.setAxisXBottom(previewXAxis());
-        previewLineData.getLines().get(4).setPointRadius(2);
         previewLineData.getLines().get(5).setPointRadius(2);
         previewLineData.getLines().get(6).setPointRadius(2);
+        previewLineData.getLines().get(7).setPointRadius(2);
         return previewLineData;
     }
 


### PR DESCRIPTION
Since adding calibrations, the high-values were bigger than the others in the preview chart at the bottom.
Adding calibrations shifted the indexes, this corrects it.
