### PR TITLE
Support for import/export of settings data to sdcard storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -220,6 +220,10 @@
         <activity
             android:name=".FollowerManagementActivity"
             android:label="Manage Followers" />
+        <activity
+            android:name=".utils.SdcardImportExport"
+            android:noHistory="true"
+            android:label="Settings on external storage" />
 
         <service
             android:name=".Services.SnoozeOnNotificationDismissService"

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Home.java
@@ -44,6 +44,7 @@ import com.eveningoutpost.dexdrip.UtilityModels.Intents;
 import com.eveningoutpost.dexdrip.stats.StatsResult;
 import com.eveningoutpost.dexdrip.utils.ActivityWithMenu;
 import com.eveningoutpost.dexdrip.utils.DatabaseUtil;
+import com.eveningoutpost.dexdrip.utils.SdcardImportExport;
 import com.eveningoutpost.dexdrip.wearintegration.WatchUpdaterService;
 import com.nispok.snackbar.Snackbar;
 import com.nispok.snackbar.SnackbarManager;
@@ -672,6 +673,12 @@ public class Home extends ActivityWithMenu {
 
         return super.onOptionsItemSelected(item);
     }
+
+    public void settingsSDcardExport(MenuItem myitem)
+    {
+        startActivity(new Intent(getApplicationContext(), SdcardImportExport.class));
+    }
+
 
     private class ChartViewPortListener implements ViewportChangeListener {
         @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/SdcardImportExport.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/SdcardImportExport.java
@@ -1,0 +1,188 @@
+package com.eveningoutpost.dexdrip.utils;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Environment;
+import android.util.Log;
+import android.view.View;
+import android.widget.Toast;
+
+import com.eveningoutpost.dexdrip.R;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class SdcardImportExport extends Activity {
+
+    private final static String TAG = "jamorham sdcard";
+
+    private final static String PREFERENCES_FILE = "shared_prefs/com.eveningoutpost.dexdrip_preferences.xml";
+
+    public static boolean deleteFolder(File path, boolean recursion) {
+        try {
+            Log.d(TAG, "deleteFolder called with: " + path.toString());
+            if (path.exists()) {
+                File[] files = path.listFiles();
+                if (files == null) {
+                    return true;
+                }
+                for (File file : files) {
+                    if ((recursion) && (file.isDirectory())) {
+                        deleteFolder(file, recursion);
+                    } else {
+                        Log.d(TAG, "Calling delete for file: " + file.getName());
+                        file.delete();
+                    }
+                }
+            }
+            return (path.delete());
+        } catch (Exception e) {
+            Log.e(TAG, "Got exception in delete: " + e.toString());
+            return false;
+        }
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sdcard_import_export);
+    }
+
+    public void savePreferencesToSD(View myview) {
+
+        if (savePreferencesToSD()) {
+            toast("Preferences saved in sdcard Downloads");
+        } else {
+            toast("Couldn't write to sdcard - check permissions?");
+        }
+    }
+
+    public void loadPreferencesToSD(View myview) {
+        if (loadPreferencesFromSD()) {
+            toast("Loaded Preferences! - Restarting");
+            // shared preferences are cached so we need a hard restart
+            android.os.Process.killProcess(android.os.Process.myPid());
+        } else {
+            toast("Could not load preferences");
+        }
+    }
+
+    public void deletePreferencesOnSD(View myview) {
+        if (!isExternalStorageWritable()) {
+            toast("External storage is not writable");
+            return;
+        }
+        if (deleteFolder(new File(getCustomSDcardpath()), false)) {
+            toast("Successfully deleted");
+        } else {
+            toast("Deletion problem");
+        }
+    }
+
+    public boolean savePreferencesToSD() {
+        if (isExternalStorageWritable()) {
+            return dataToSDcopy(PREFERENCES_FILE);
+        } else {
+            toast("SDcard not writable - cannot save");
+            return false;
+        }
+    }
+
+    public boolean loadPreferencesFromSD() {
+        if (isExternalStorageWritable()) {
+            return dataFromSDcopy(PREFERENCES_FILE);
+        } else {
+            toast("SDcard not readable");
+            return false;
+        }
+    }
+
+    private boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        if (Environment.MEDIA_MOUNTED.equals(state)) {
+            return true;
+        }
+        return false;
+    }
+
+    private String getCustomSDcardpath() {
+        return Environment.getExternalStoragePublicDirectory(
+                Environment.DIRECTORY_DOWNLOADS) + "/xDrip-export";
+    }
+
+    private boolean dataToSDcopy(String filename) {
+        File source_file = new File(getFilesDir().getParent() + "/" + filename);
+        String path = getCustomSDcardpath();
+        File fpath = new File(path);
+        try {
+            fpath.mkdirs();
+            File dest_file = new File(path, source_file.getName());
+
+            if (directCopyFile(source_file, dest_file)) {
+                Log.i(TAG, "Copied success: " + filename);
+                return true;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error making directory: " + path.toString());
+            return false;
+        }
+        return false;
+    }
+
+    private boolean dataFromSDcopy(String filename) {
+        File dest_file = new File(getFilesDir().getParent() + "/" + filename);
+        File source_file = new File(getCustomSDcardpath() + "/" + dest_file.getName());
+        try {
+            dest_file.mkdirs();
+            if (directCopyFile(source_file, dest_file)) {
+                Log.i(TAG, "Copied success: " + filename);
+                return true;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Error making directory: " + dest_file.toString());
+            return false;
+        }
+        return false;
+    }
+
+    private boolean directCopyFile(File source_filename, File dest_filename) {
+        Log.i(TAG, "Attempt to copy: " + source_filename.toString() + " to " + dest_filename.toString());
+        InputStream in = null;
+        OutputStream out = null;
+        try {
+            in = new FileInputStream(source_filename);
+            out = new FileOutputStream(dest_filename);
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+            in.close();
+            in = null;
+            out.flush();
+            out.close();
+            out = null;
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage());
+        }
+        return false;
+    }
+
+    private void toast(String msg) {
+        try {
+            Toast.makeText(getApplicationContext(), msg, Toast.LENGTH_SHORT).show();
+            Log.d(TAG, "Toast msg: " + msg);
+        } catch (Exception e) {
+            Log.e(TAG, "Couldn't display toast: " + msg);
+        }
+    }
+
+    public void closeButton(View myview) {
+        finish();
+    }
+
+}

--- a/app/src/main/res/layout/activity_sdcard_import_export.xml
+++ b/app/src/main/res/layout/activity_sdcard_import_export.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="com.eveningoutpost.dexdrip.utils.SdcardImportExport">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/linearLayout">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Here you can save the settings to the external storage (sdcard).\n\nOnce saved to the external storage it is potentially possible for any app to read the settings which might contain sensitive information.\n\nYou are advised to delete the settings once you have imported them again if you are concerned about this."
+            android:id="@+id/warningtext"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true" />
+
+        <Button
+            android:layout_marginTop="28dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Save all Settings to SDcard"
+            android:id="@+id/saveallsettings"
+            android:onClick="savePreferencesToSD"
+            android:layout_centerVertical="true"
+            android:layout_alignParentStart="true" />
+
+        <Button
+            android:layout_marginTop="28dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Load all Settings from SDcard"
+            android:id="@+id/buttonload"
+            android:onClick="loadPreferencesToSD"
+            android:layout_below="@+id/saveallsettings"
+            android:layout_alignStart="@+id/saveallsettings" />
+
+        <Button
+            android:layout_marginTop="28dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Delete any settings on SDcard"
+            android:id="@+id/buttondelete"
+            android:onClick="deletePreferencesOnSD"
+            android:layout_below="@+id/buttonload"
+            android:layout_alignStart="@+id/buttonload" />
+
+    </LinearLayout>
+
+    <ImageButton
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/closebutton"
+        android:onClick="closeButton"
+        android:layout_gravity="end"
+        android:src="@android:drawable/ic_delete"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentEnd="true" />
+
+</RelativeLayout>

--- a/app/src/main/res/menu/menu_home.xml
+++ b/app/src/main/res/menu/menu_home.xml
@@ -31,6 +31,14 @@
         android:orderInCategory="1"
         app:showAsAction="never"/>
 
+    <item android:id="@+id/importsettings"
+        android:title="Settings to external storage"
+        android:checkable="false"
+        android:onClick="settingsSDcardExport"
+        android:visible="true"
+        android:orderInCategory="1"
+        android:showAsAction="never"/>
+
     <item android:id="@+id/action_toggle_speakreadings"
         android:title="@string/menu_toggle_speakreadings"
         android:checkable="true"


### PR DESCRIPTION
This patch allows the user to load and save the settings file to the external storage.

I find it a real pain re-entering settings after an uninstall or changing signing keys etc. This solves the problem for preferences settings.

Tested on android 4.4 / 5 and 6
