### PR TITLE
Fix false low notifications

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Sensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Sensor.java
@@ -90,6 +90,11 @@ public class Sensor extends Model {
     }
 
     public static void updateBatteryLevel(Sensor sensor, int sensorBatteryLevel) {
+        if(sensorBatteryLevel < 120) {
+            // This must be a wrong battery level. Some transmitter send those every couple of readings
+            // even if the battery is ok.
+            return;
+        }
         int startBatteryLevel = sensor.latest_battery_level;
         if(sensor.latest_battery_level == 0) {
             sensor.latest_battery_level = sensorBatteryLevel;


### PR DESCRIPTION
People were complaining on Facebook (and here a few month back) that XDrip alerted for an empty transmitter even though it was quite new.

Some transmitter seem to send impossibly low battery values from time to time and therefore cause the alert. With this PR we will just accept battery levels above 120. (This is much lower than I have ever seen a transmitter being able to transmit anything).
