### PR TITLE
wear: match default values in settings and code

### DIFF
--- a/wear/src/main/java/com/eveningoutpost/dexdrip/BIGChart.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/BIGChart.java
@@ -266,7 +266,7 @@ public class BIGChart extends WatchFace implements SharedPreferences.OnSharedPre
     }
 
     public void setColor() {
-        if (sharedPrefs.getBoolean("dark", false)) {
+        if (sharedPrefs.getBoolean("dark", true)) {
             setColorDark();
         } else {
             setColorBright();

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/BaseWatchFace.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/BaseWatchFace.java
@@ -259,7 +259,7 @@ public  abstract class BaseWatchFace extends WatchFace implements SharedPreferen
     }
 
     public void setColor() {
-        if (sharedPrefs.getBoolean("dark", false)) {
+        if (sharedPrefs.getBoolean("dark", true)) {
             setColorDark();
         } else {
             setColorBright();

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/CircleWatchface.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/CircleWatchface.java
@@ -337,7 +337,7 @@ public class CircleWatchface extends WatchFace implements SharedPreferences.OnSh
 
     // defining color for dark and bright
     public int getLowColor() {
-        if (sharedPrefs.getBoolean("dark", false)) {
+        if (sharedPrefs.getBoolean("dark", true)) {
             return Color.argb(255, 255, 120, 120);
         } else {
             return Color.argb(255, 255, 80, 80);


### PR DESCRIPTION
The watchfaces should have a black background by default. The default value was just set in the settings but not in the code. Without changing it in the settings at least once the settings did not represent the actual behaviour.
