### PR TITLE
Restrict data fetched for ongoing Notification

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ForegroundServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ForegroundServiceStarter.java
@@ -34,9 +34,7 @@ public class ForegroundServiceStarter {
             mHandler.post(new Runnable() {
                 @Override
                 public void run() {
-                    long end = System.currentTimeMillis() + (60000 * 5);
-                    long start = end - (60000 * 60*3) -  (60000 * 10);
-                    mService.startForeground(new Notifications().ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext));
+                    mService.startForeground(new Notifications().ongoingNotificationId, new Notifications().createOngoingNotification(mContext));
                 }
             });
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ForegroundServiceStarter.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/ForegroundServiceStarter.java
@@ -8,6 +8,8 @@ import android.os.Looper;
 import android.preference.PreferenceManager;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
 
+import java.util.Date;
+
 /**
  * Created by stephenblack on 12/25/14.
  */
@@ -32,7 +34,9 @@ public class ForegroundServiceStarter {
             mHandler.post(new Runnable() {
                 @Override
                 public void run() {
-                    mService.startForeground(new Notifications().ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext), mContext));
+                    long end = System.currentTimeMillis() + (60000 * 5);
+                    long start = end - (60000 * 60*3) -  (60000 * 10);
+                    mService.startForeground(new Notifications().ongoingNotificationId, new Notifications().createOngoingNotification(new BgGraphBuilder(mContext, start, end), mContext));
                 }
             });
         }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/Notifications.java
@@ -245,9 +245,8 @@ public class Notifications extends IntentService {
 
     private void notificationSetter(Context context) {
         ReadPerfs(context);
-        BgGraphBuilder bgGraphBuilder = new BgGraphBuilder(context);
         if (bg_ongoing && (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)) {
-            bgOngoingNotification(bgGraphBuilder);
+            bgOngoingNotification();
         }
         if (prefs.getLong("alerts_disabled_until", 0) > new Date().getTime()) {
             Log.d("NOTIFICATIONS", "Notifications are currently disabled!!");
@@ -409,8 +408,11 @@ public class Notifications extends IntentService {
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-    public Notification createOngoingNotification(BgGraphBuilder bgGraphBuilder, Context context) {
+    public Notification createOngoingNotification(Context context) {
         mContext = context;
+        long end = System.currentTimeMillis() + (60000 * 5);
+        long start = end - (60000 * 60*3) -  (60000 * 10);
+        BgGraphBuilder bgGraphBuilder = new BgGraphBuilder(mContext, start, end);
         ReadPerfs(mContext);
         Intent intent = new Intent(mContext, Home.class);
         List<BgReading> lastReadings = BgReading.latest(2);
@@ -462,13 +464,13 @@ public class Notifications extends IntentService {
         return b.build();
     }
 
-    private void bgOngoingNotification(final BgGraphBuilder bgGraphBuilder) {
+    private void bgOngoingNotification() {
         mHandler.post(new Runnable() {
             @Override
             public void run() {
                 NotificationManagerCompat
                         .from(mContext)
-                        .notify(ongoingNotificationId, createOngoingNotification(bgGraphBuilder, mContext));
+                        .notify(ongoingNotificationId, createOngoingNotification(mContext));
                 if (iconBitmap != null)
                     iconBitmap.recycle();
                 if (notifiationBitmap != null)


### PR DESCRIPTION
This restricts the data fetched for the ongoing notification to the data that is needed.
It will not fetch the whole day but just the 3 hours shown in the notification.

This also fixes the bug that values hours before the values shown in the chart affect how it is stretched on the y axis. Thanks @fezulin for reporting this.
