### PR TITLE
Wear crash fix

### DIFF
--- a/wear/src/main/java/com/eveningoutpost/dexdrip/BIGChart.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/BIGChart.java
@@ -438,11 +438,11 @@ public class BIGChart extends WatchFace implements SharedPreferences.OnSharedPre
     public void missedReadingAlert() {
         int minutes_since   = (int) Math.floor(timeSince()/(1000*60));
         if(minutes_since >= 16 && ((minutes_since - 16) % 5) == 0) {
-            NotificationCompat.Builder notification = new NotificationCompat.Builder(getApplicationContext())
+            /*NotificationCompat.Builder notification = new NotificationCompat.Builder(getApplicationContext())
                     .setContentTitle("Missed BG Readings")
                     .setVibrate(vibratePattern);
-            NotificationManager mNotifyMgr = (NotificationManager) getApplicationContext().getSystemService(getApplicationContext().NOTIFICATION_SERVICE);
-            mNotifyMgr.notify(missed_readings_alert_id, notification.build());
+            NotificationManager mNotifyMgr = (hNotificationManager) getApplicationContext().getSystemService(getApplicationContext().NOTIFICATION_SERVICE);
+            mNotifyMgr.notify(missed_readings_alert_id, notification.build());*/
             ListenerService.requestData(this); // attempt to recover missing data
         }
     }

--- a/wear/src/main/java/com/eveningoutpost/dexdrip/BaseWatchFace.java
+++ b/wear/src/main/java/com/eveningoutpost/dexdrip/BaseWatchFace.java
@@ -287,11 +287,11 @@ protected abstract void setColorDark();
     public void missedReadingAlert() {
         int minutes_since   = (int) Math.floor(timeSince()/(1000*60));
         if(minutes_since >= 16 && ((minutes_since - 16) % 5) == 0) {
-            NotificationCompat.Builder notification = new NotificationCompat.Builder(getApplicationContext())
+            /*NotificationCompat.Builder notification = new NotificationCompat.Builder(getApplicationContext())
                         .setContentTitle("Missed BG Readings")
                         .setVibrate(vibratePattern);
             NotificationManager mNotifyMgr = (NotificationManager) getApplicationContext().getSystemService(getApplicationContext().NOTIFICATION_SERVICE);
-            mNotifyMgr.notify(missed_readings_alert_id, notification.build());
+            mNotifyMgr.notify(missed_readings_alert_id, notification.build());*/
             ListenerService.requestData(this); // attempt to recover missing data
         }
     }


### PR DESCRIPTION
This is an emergency fix.

The Notification I commented out apparently never was shown as it always caused an exception. It is also unnecessary as the alarm system on the phone's side has a missed readings alert.

With the update for wear watches that rolled out in the last couple of days, it now crashes that it can only recover by rebooting.
