### PR TITLE
Do calculations as float and not as int for plotting points.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -37,7 +37,7 @@ import lecho.lib.hellocharts.view.Chart;
  * Created by stephenblack on 11/15/14.
  */
 public class BgGraphBuilder {
-    public static final int FUZZER = (1000 * 30 * 5);
+    public static final float FUZZER = (1000 * 30 * 5);
     public long  end_time;
     public long  start_time;
     public Context context;
@@ -452,7 +452,7 @@ public class BgGraphBuilder {
         public synchronized void onValueSelected(int i, int i1, PointValue pointValue) {
             final java.text.DateFormat timeFormat = DateFormat.getTimeFormat(context);
             //Won't give the exact time of the reading but the time on the grid: close enough.
-            Long time = ((long)pointValue.getX())*FUZZER;
+            Long time = (long)(pointValue.getX()*FUZZER);
             if(tooltip!= null){
                 tooltip.cancel();
             }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgSparklineBuilder.java
@@ -32,8 +32,8 @@ public class BgSparklineBuilder {
     private int height;
     private BgGraphBuilder bgGraphBuilder;
     private LineChartView chart;
-    private long end = new Date().getTime() / BgGraphBuilder.FUZZER;
-    private long start = end - (60000*180 / BgGraphBuilder.FUZZER); // 3h
+    private long end = new Date().getTime() / (long)BgGraphBuilder.FUZZER;
+    private long start = end - (60000*180 / (long)BgGraphBuilder.FUZZER); // 3h
     private boolean showLowLine = false;
     private boolean showHighLine = false;
     private boolean showAxes = false;
@@ -41,12 +41,12 @@ public class BgSparklineBuilder {
     private boolean useTinyDots = false;
 
     public BgSparklineBuilder setStart(long start) {
-        this.start = start / BgGraphBuilder.FUZZER;
+        this.start = start / (long)BgGraphBuilder.FUZZER;
         return this;
     }
 
     public BgSparklineBuilder setEnd(long end) {
-        this.end = end / BgGraphBuilder.FUZZER;
+        this.end = end / (long)BgGraphBuilder.FUZZER;
         return this;
     }
 


### PR DESCRIPTION
This fixes a problem where points some times seemed too close to each other.

Signed-off-by: Tzachi Dar tzachi.dar@gmail.com

The current code moves from seconds to units of 2.5 minutes.
As a result, since due to measuring errors two points are not guaranteed to be in 5 minutes apart, they might end much closer than they should be.

I'll upload pictures tomorrow for the change.
