### PR TITLE
Add timeout on mongo send/receive operations.

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Services/MongoWrapper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Services/MongoWrapper.java
@@ -36,7 +36,7 @@ public class MongoWrapper {
 	// Unfortunately, this also throws other exceptions that are not documetned...
     public DBCollection openMongoDb() throws UnknownHostException {
 
-    	MongoClientURI dbUri = new MongoClientURI(dbUriStr_); //?? thros
+    	MongoClientURI dbUri = new MongoClientURI(dbUriStr_+"?socketTimeoutMS=180000");
 	    mongoClient_ = new MongoClient(dbUri);
 
 	    DB db = mongoClient_.getDB( dbName_ );

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/NightscoutUploader.java
@@ -323,7 +323,7 @@ public class NightscoutUploader {
                 try {
 
                     // connect to db
-                    MongoClientURI uri = new MongoClientURI(dbURI.trim());
+                    MongoClientURI uri = new MongoClientURI(dbURI.trim()+"?socketTimeoutMS=180000");
                     MongoClient client = new MongoClient(uri);
 
                     // get db


### PR DESCRIPTION
Signed-off-by: Tzachi Dar tzachi.dar@gmail.com

This is a fix for the problem of mongo upload operations that got stuck.
It seems that we have not configured timeout on the operations and as a result, this might got stuck for ever.
Verified the fix is working with much smaller timeouts.
