### PR TITLE
pause before reading, stop scan w/ sensor stop

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/StopSensor.java
@@ -1,17 +1,27 @@
 package com.eveningoutpost.dexdrip;
 
+import android.bluetooth.BluetoothDevice;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+
+import com.eveningoutpost.dexdrip.G5Model.Extensions;
+import com.eveningoutpost.dexdrip.G5Model.Transmitter;
 import com.eveningoutpost.dexdrip.Models.UserError.Log;
+
+import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
 
 import com.eveningoutpost.dexdrip.Models.Sensor;
+import com.eveningoutpost.dexdrip.Services.G5CollectionService;
 import com.eveningoutpost.dexdrip.UtilityModels.AlertPlayer;
 import com.eveningoutpost.dexdrip.utils.ActivityWithMenu;
 
+import java.lang.reflect.Method;
 import java.util.Date;
+import java.util.Set;
 
 public class StopSensor extends ActivityWithMenu {
     public static String menu_name = "Stop Sensor";
@@ -43,9 +53,18 @@ public class StopSensor extends ActivityWithMenu {
         button.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 Sensor.stopSensor();
-                AlertPlayer.getPlayer().stopAlert(getApplicationContext(),true, false);
+                AlertPlayer.getPlayer().stopAlert(getApplicationContext(), true, false);
 
                 Toast.makeText(getApplicationContext(), "Sensor stopped", Toast.LENGTH_LONG).show();
+
+                //If Sensor is stopped for G5, we need to prevent further BLE scanning.
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+                String collection_method = prefs.getString("dex_collection_method", "BluetoothWixel");
+                if(collection_method.compareTo("DexcomG5") == 0) {
+                    Intent serviceIntent = new Intent(getApplicationContext(), G5CollectionService.class);
+                    startService(serviceIntent);
+                }
+
                 Intent intent = new Intent(getApplicationContext(), Home.class);
                 startActivity(intent);
                 finish();


### PR DESCRIPTION
Inducing a brief delay to test improved receiver/xDrip cooperation & reliability in getting data. Current theory is that they both begin requesting data when the G5 begins advertising.. colliding & preventing the receiver from getting data.

Also, when the sensor session is ended, the G5 service will stop scanning. This will prevent unwanted re-auth/bonding when a user decides they no longer wish to use xDrip.

also fixed issue presented in crash data (stopScan request when not scanning)
