### PR TITLE
Android wear loc

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
@@ -3,7 +3,6 @@ package com.eveningoutpost.dexdrip.wearintegration;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import com.eveningoutpost.dexdrip.Models.UserError;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataMap;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
@@ -3,6 +3,7 @@ package com.eveningoutpost.dexdrip.wearintegration;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import com.eveningoutpost.dexdrip.Models.UserError;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataMap;
@@ -12,11 +13,14 @@ import com.google.android.gms.wearable.PutDataMapRequest;
 import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Created by stephenblack on 12/26/14.
  */
 class SendToDataLayerThread extends AsyncTask<DataMap,Void,Void> {
     private GoogleApiClient googleApiClient;
+    private static final String TAG = "SendDataThread";
     String path;
 
     SendToDataLayerThread(String path, GoogleApiClient pGoogleApiClient) {
@@ -26,21 +30,24 @@ class SendToDataLayerThread extends AsyncTask<DataMap,Void,Void> {
 
     @Override
     protected Void doInBackground(DataMap... params) {
-        NodeApi.GetConnectedNodesResult nodes = Wearable.NodeApi.getConnectedNodes(googleApiClient).await();
-        for (Node node : nodes.getNodes()) {
-            for (DataMap dataMap : params) {
-                PutDataMapRequest putDMR = PutDataMapRequest.create(path);
-                putDMR.getDataMap().putAll(dataMap);
-                PutDataRequest request = putDMR.asPutDataRequest();
-                DataApi.DataItemResult result = Wearable.DataApi.putDataItem(googleApiClient,request).await();
-                if (result.getStatus().isSuccess()) {
-                    Log.d("SendDataThread", "DataMap: " + dataMap + " sent to: " + node.getDisplayName());
-                } else {
-                    Log.d("SendDataThread", "ERROR: failed to send DataMap");
+        try {
+            final NodeApi.GetConnectedNodesResult nodes = Wearable.NodeApi.getConnectedNodes(googleApiClient).await(15, TimeUnit.SECONDS);
+            for (Node node : nodes.getNodes()) {
+                for (DataMap dataMap : params) {
+                    PutDataMapRequest putDMR = PutDataMapRequest.create(path);
+                    putDMR.getDataMap().putAll(dataMap);
+                    PutDataRequest request = putDMR.asPutDataRequest();
+                    DataApi.DataItemResult result = Wearable.DataApi.putDataItem(googleApiClient, request).await(15, TimeUnit.SECONDS);
+                    if (result.getStatus().isSuccess()) {
+                        Log.d(TAG, "DataMap: " + dataMap + " sent to: " + node.getDisplayName());
+                    } else {
+                        Log.d(TAG, "ERROR: failed to send DataMap");
+                    }
                 }
             }
+        } catch (Exception e) {
+            Log.e(TAG, "Got exception sending data to wear: " + e.toString());
         }
-
         return null;
     }
 }


### PR DESCRIPTION
On some platforms it appears that the API for Android Wear can lock up resulting in the await() call never returning within SendToDataLayerThread.java

This patch adds a 15 second timeout to getConnectedNodes() and putDataItem()

Thanks jamorham
