### PR TITLE
Chart Filtered Data / Database Schema updates / Treatment model

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
             android:value="DexDrip.db" />
         <meta-data
             android:name="AA_DB_VERSION"
-            android:value="37" />
+            android:value="41" />
 
         <provider
             android:name="com.activeandroid.content.ContentProvider"

--- a/app/src/main/assets/migrations/38.sql
+++ b/app/src/main/assets/migrations/38.sql
@@ -1,0 +1,1 @@
+ALTER TABLE BgReadings ADD COLUMN filtered_calculated_value REAL DEFAULT 0;

--- a/app/src/main/assets/migrations/41.sql
+++ b/app/src/main/assets/migrations/41.sql
@@ -1,2 +1,3 @@
+DELETE FROM BgReadings WHERE rowid NOT IN (SELECT MAX(rowid) FROM BgReadings GROUP BY uuid);
 DROP INDEX index_BgReadings_uuid;
 CREATE UNIQUE INDEX index_BgReadings_uuid on BgReadings(uuid);

--- a/app/src/main/assets/migrations/41.sql
+++ b/app/src/main/assets/migrations/41.sql
@@ -1,0 +1,2 @@
+DROP INDEX index_BgReadings_uuid;
+CREATE UNIQUE INDEX index_BgReadings_uuid on BgReadings(uuid);

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -74,6 +74,10 @@ public class BgReading extends Model implements ShareUploadableBg{
     public double calculated_value;
 
     @Expose
+    @Column(name = "filtered_calculated_value")
+    public double filtered_calculated_value;
+
+    @Expose
     @Column(name = "calculated_value_slope")
     public double calculated_value_slope;
 
@@ -101,7 +105,7 @@ public class BgReading extends Model implements ShareUploadableBg{
     @Column(name = "rc")
     public double rc;
     @Expose
-    @Column(name = "uuid", index = true)
+    @Column(name = "uuid", unique = true , onUniqueConflicts = Column.ConflictAction.IGNORE)
     public String uuid;
 
     @Expose
@@ -352,6 +356,7 @@ public class BgReading extends Model implements ShareUploadableBg{
                     }
                 }
                 bgReading.calculated_value = ((calibration.slope * bgReading.age_adjusted_raw_value) + calibration.intercept);
+                bgReading.filtered_calculated_value = ((calibration.slope * bgReading.ageAdjustedFiltered()) + calibration.intercept);
             }
             updateCalculatedValue(bgReading);
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -347,6 +347,7 @@ public class BgReading extends Model implements ShareUploadableBg{
                 double calSlope = (calibration.first_scale / firstAdjSlope)*1000;
                 double calIntercept = ((calibration.first_scale * calibration.first_intercept) / firstAdjSlope)*-1;
                 bgReading.calculated_value = (((calSlope * bgReading.raw_data) + calIntercept) - 5);
+                bgReading.filtered_calculated_value = (((calSlope * bgReading.ageAdjustedFiltered()) + calIntercept) -5);
 
             } else {
                 BgReading lastBgReading = BgReading.last();

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/Treatments.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/Treatments.java
@@ -1,0 +1,50 @@
+package com.eveningoutpost.dexdrip.Models;
+
+/**
+ * Created by jamorham on 20/02/2016.
+ */
+
+import android.provider.BaseColumns;
+
+import com.activeandroid.Model;
+import com.activeandroid.annotation.Column;
+import com.activeandroid.annotation.Table;
+import com.google.gson.annotations.Expose;
+
+// Nightscout Treatments database fields
+
+@Table(name = "Treatments", id = BaseColumns._ID)
+public class Treatments extends Model {
+    @Expose
+    @Column(name = "timestamp", index = true)
+    public long timestamp;
+
+    @Expose
+    @Column(name = "eventType")
+    public String eventType;
+
+    @Expose
+    @Column(name = "enteredBy")
+    public String enteredBy;
+
+    @Expose
+    @Column(name = "notes")
+    public String notes;
+
+    @Expose
+    @Column(name = "uuid", unique = true, onUniqueConflicts = Column.ConflictAction.IGNORE)
+    public String uuid;
+
+    @Expose
+    @Column(name = "carbs")
+    public double carbs;
+
+    @Expose
+    @Column(name = "insulin")
+    public double insulin;
+
+    @Expose
+    @Column(name = "created_at")
+    public String created_at;
+
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -129,7 +129,7 @@ public class BgGraphBuilder {
         lines.add(highLine());
         lines.add(lowLine());
 
-        if (prefs.getBoolean("show_filtered_curve", true)) {
+        if (prefs.getBoolean("show_filtered_curve", false)) {
             final ArrayList<Line> filtered_lines = filteredLines();
             for (Line thisline : filtered_lines) {
                 lines.add(thisline);
@@ -230,27 +230,29 @@ public class BgGraphBuilder {
 
 
     private void addBgReadingValues() {
+        final boolean show_filtered = prefs.getBoolean("show_filtered_curve", false);
+
         for (BgReading bgReading : bgReadings) {
             if (bgReading.raw_calculated != 0 && prefs.getBoolean("interpret_raw", false)) {
-                rawInterpretedValues.add(new PointValue((float) (bgReading.timestamp/ FUZZER), (float) unitized(bgReading.raw_calculated)));
+                rawInterpretedValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.raw_calculated)));
             } else if (bgReading.calculated_value >= 400) {
-                highValues.add(new PointValue((float) (bgReading.timestamp/ FUZZER), (float) unitized(400)));
+                highValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(400)));
             } else if (unitized(bgReading.calculated_value) >= highMark) {
-                highValues.add(new PointValue((float) (bgReading.timestamp/ FUZZER), (float) unitized(bgReading.calculated_value)));
+                highValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
             } else if (unitized(bgReading.calculated_value) >= lowMark) {
-                inRangeValues.add(new PointValue((float) (bgReading.timestamp/ FUZZER), (float) unitized(bgReading.calculated_value)));
+                inRangeValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
             } else if (bgReading.calculated_value >= 40) {
-                lowValues.add(new PointValue((float)(bgReading.timestamp/ FUZZER), (float) unitized(bgReading.calculated_value)));
+                lowValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(bgReading.calculated_value)));
             } else if (bgReading.calculated_value > 13) {
-                lowValues.add(new PointValue((float)(bgReading.timestamp/ FUZZER), (float) unitized(40)));
+                lowValues.add(new PointValue((float) (bgReading.timestamp / FUZZER), (float) unitized(40)));
             }
 
-            if ((bgReading.filtered_calculated_value > 0) &&(bgReading.filtered_calculated_value != bgReading.calculated_value)) {
+            if ((show_filtered) && (bgReading.filtered_calculated_value > 0) && (bgReading.filtered_calculated_value != bgReading.calculated_value)) {
                 filteredValues.add(new PointValue((float) ((bgReading.timestamp - timeshift) / FUZZER), (float) unitized(bgReading.filtered_calculated_value)));
             }
         }
         for (Calibration calibration : calibrations) {
-            calibrationValues.add(new PointValue((float)(calibration.timestamp/ FUZZER), (float) unitized(calibration.bg)));
+            calibrationValues.add(new PointValue((float) (calibration.timestamp / FUZZER), (float) unitized(calibration.bg)));
         }
     }
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/UtilityModels/BgGraphBuilder.java
@@ -180,37 +180,35 @@ public class BgGraphBuilder {
         return line;
     }
 
+    // Produce an array of cubic lines, split as needed
     public ArrayList<Line> filteredLines() {
-        ArrayList<Line> linearray = new ArrayList<Line>();
-        float lastx = -999999;
-        float jumpthresh = 15; // in minutes
-        List<PointValue> thesepoints = new ArrayList<PointValue>();
+        ArrayList<Line> line_array = new ArrayList<Line>();
+        float last_x_pos = -999999; // bogus mark value
+        final float jump_threshold = 15; // in minutes
+        List<PointValue> local_points = new ArrayList<PointValue>();
 
         if (filteredValues.size() > 0) {
+            final float end_marker = filteredValues.get(filteredValues.size() - 1).getX();
 
-            final float endmarker = filteredValues.get(filteredValues.size() - 1).getX();
-
-            for (PointValue thispoint : filteredValues) {
+            for (PointValue current_point : filteredValues) {
                 // a jump too far for a line? make it a new one
-                if (((lastx != -999999) && (Math.abs(thispoint.getX() - lastx) > jumpthresh))
-                        || thispoint.getX() == endmarker) {
-                    Line line = new Line(thesepoints);
+                if (((last_x_pos != -999999) && (Math.abs(current_point.getX() - last_x_pos) > jump_threshold))
+                        || current_point.getX() == end_marker) {
+                    Line line = new Line(local_points);
                     line.setHasPoints(true);
                     line.setPointRadius(2);
                     line.setStrokeWidth(1);
                     line.setColor(Color.parseColor("#a0a0a0"));
                     line.setCubic(true);
                     line.setHasLines(true);
-                    linearray.add(line);
-                    thesepoints = new ArrayList<PointValue>();
+                    line_array.add(line);
+                    local_points = new ArrayList<PointValue>();
                 }
-
-                lastx = thispoint.getX();
-                thesepoints.add(thispoint); // grow current line list
+                last_x_pos = current_point.getX();
+                local_points.add(current_point); // grow current line list
             }
         }
-
-        return linearray;
+        return line_array;
     }
 
     public Line[] calibrationValuesLine() {

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
@@ -3,7 +3,6 @@ package com.eveningoutpost.dexdrip.wearintegration;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import com.eveningoutpost.dexdrip.Models.UserError;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataMap;

--- a/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/wearintegration/SendToDataLayerThread.java
@@ -3,6 +3,7 @@ package com.eveningoutpost.dexdrip.wearintegration;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import com.eveningoutpost.dexdrip.Models.UserError;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.wearable.DataApi;
 import com.google.android.gms.wearable.DataMap;
@@ -12,11 +13,14 @@ import com.google.android.gms.wearable.PutDataMapRequest;
 import com.google.android.gms.wearable.PutDataRequest;
 import com.google.android.gms.wearable.Wearable;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Created by stephenblack on 12/26/14.
  */
 class SendToDataLayerThread extends AsyncTask<DataMap,Void,Void> {
     private GoogleApiClient googleApiClient;
+    private static final String TAG = "SendDataThread";
     String path;
 
     SendToDataLayerThread(String path, GoogleApiClient pGoogleApiClient) {
@@ -26,21 +30,24 @@ class SendToDataLayerThread extends AsyncTask<DataMap,Void,Void> {
 
     @Override
     protected Void doInBackground(DataMap... params) {
-        NodeApi.GetConnectedNodesResult nodes = Wearable.NodeApi.getConnectedNodes(googleApiClient).await();
-        for (Node node : nodes.getNodes()) {
-            for (DataMap dataMap : params) {
-                PutDataMapRequest putDMR = PutDataMapRequest.create(path);
-                putDMR.getDataMap().putAll(dataMap);
-                PutDataRequest request = putDMR.asPutDataRequest();
-                DataApi.DataItemResult result = Wearable.DataApi.putDataItem(googleApiClient,request).await();
-                if (result.getStatus().isSuccess()) {
-                    Log.d("SendDataThread", "DataMap: " + dataMap + " sent to: " + node.getDisplayName());
-                } else {
-                    Log.d("SendDataThread", "ERROR: failed to send DataMap");
+        try {
+            final NodeApi.GetConnectedNodesResult nodes = Wearable.NodeApi.getConnectedNodes(googleApiClient).await(15, TimeUnit.SECONDS);
+            for (Node node : nodes.getNodes()) {
+                for (DataMap dataMap : params) {
+                    PutDataMapRequest putDMR = PutDataMapRequest.create(path);
+                    putDMR.getDataMap().putAll(dataMap);
+                    PutDataRequest request = putDMR.asPutDataRequest();
+                    DataApi.DataItemResult result = Wearable.DataApi.putDataItem(googleApiClient, request).await(15, TimeUnit.SECONDS);
+                    if (result.getStatus().isSuccess()) {
+                        Log.d(TAG, "DataMap: " + dataMap + " sent to: " + node.getDisplayName());
+                    } else {
+                        Log.d(TAG, "ERROR: failed to send DataMap");
+                    }
                 }
             }
+        } catch (Exception e) {
+            Log.e(TAG, "Got exception sending data to wear: " + e.toString());
         }
-
         return null;
     }
 }

--- a/app/src/main/res/xml/pref_advanced_settings.xml
+++ b/app/src/main/res/xml/pref_advanced_settings.xml
@@ -37,6 +37,11 @@
             android:summary="If using Share, DexDrip will show values when they are normally hidden on the receiver."
             android:defaultValue="false" />
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="show_filtered_curve"
+            android:summary="Useful for noise and missed readings"
+            android:title="Display filtered plot" />
+        <CheckBoxPreference
             android:key="bg_to_speech"
             android:title="Speak Readings"
             android:summary="If the phone has text-to-speech capabilities it will read new readings out loud."


### PR DESCRIPTION
This adds an optional plot of the filtered data readings available from WiFi Wixels / Parakeet / xBridge etc. (Note the grey line and dots on the attached screen shot)

To facilitate this, the database schema is changed to add `filtered_calculated_value` to the `BgReadings` table. 

At the same time the `BgReadings` `UUID` field is enforced as actually unique and a model is added for `Treatments`

This mirrors the database structure used by xDrip+ which takes the database field names from Nightscout for easier integration of treatments syncing etc. These changes make the database structure compatible between xDrip+ and xDrip. 

![screenshot_2016-04-27-10-35-46](https://cloud.githubusercontent.com/assets/12565568/14855097/4540ba50-0c8a-11e6-837a-8f81d30f786a.png)
