### PR TITLE
Possibility to flag readings to exclude from statistics

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/BgReading.java
@@ -119,8 +119,9 @@ public class BgReading extends Model implements ShareUploadableBg{
     @Column(name = "sensor_uuid", index = true)
     public String sensor_uuid;
 
+    // mapped to the no longer used "synced" to keep DB Scheme compatible
     @Column(name = "snyced")
-    public boolean synced;
+    public boolean ignoreForStats;
 
     @Column(name = "raw_calculated")
     public double raw_calculated;
@@ -230,7 +231,6 @@ public class BgReading extends Model implements ShareUploadableBg{
                 if(bgReading.timestamp > new Date().getTime()) { return; }
                 bgReading.uuid = UUID.randomUUID().toString();
                 bgReading.time_since_sensor_started = bgReading.timestamp - sensor.started_at;
-                bgReading.synced = false;
                 bgReading.calculateAgeAdjustedRawValue(context);
                 bgReading.save();
             }
@@ -320,7 +320,6 @@ public class BgReading extends Model implements ShareUploadableBg{
             bgReading.timestamp = timestamp;
             bgReading.uuid = UUID.randomUUID().toString();
             bgReading.time_since_sensor_started = bgReading.timestamp - sensor.started_at;
-            bgReading.synced = false;
             bgReading.calibration_flag = false;
 
             bgReading.calculateAgeAdjustedRawValue(context);
@@ -338,7 +337,6 @@ public class BgReading extends Model implements ShareUploadableBg{
             bgReading.timestamp = timestamp;
             bgReading.uuid = UUID.randomUUID().toString();
             bgReading.time_since_sensor_started = bgReading.timestamp - sensor.started_at;
-            bgReading.synced = false;
 
             bgReading.calculateAgeAdjustedRawValue(context);
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
@@ -1,8 +1,9 @@
 package com.eveningoutpost.dexdrip.Tables;
 
+import android.app.AlertDialog;
 import android.app.ListActivity;
 import android.content.Context;
-import android.database.Cursor;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v4.widget.DrawerLayout;
 import android.view.LayoutInflater;
@@ -89,13 +90,40 @@ public class BgReadingTable extends ListActivity implements NavigationDrawerFrag
             return view;
         }
 
-        public void bindView(View view, Context context, BgReading bgReading) {
+        public void bindView(View view, final Context context, final BgReading bgReading) {
             final BgReadingCursorAdapterViewHolder tag = (BgReadingCursorAdapterViewHolder) view.getTag();
             tag.calculated_value.setText(Double.toString(bgReading.calculated_value));
             tag.filtered_calculated_value.setText(Double.toString(bgReading.filtered_calculated_value));
             tag.age_adjusted_raw_value.setText(Double.toString(bgReading.age_adjusted_raw_value));
             tag.raw_data.setText(Double.toString(bgReading.raw_data));
             tag.raw_data_timestamp.setText(new Date(bgReading.timestamp).toString());
+            view.setLongClickable(true);
+            view.setOnLongClickListener(new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View v) {
+                    DialogInterface.OnClickListener dialogClickListener = new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            switch (which){
+                                case DialogInterface.BUTTON_POSITIVE:
+                                    bgReading.ignoreForStats = true;
+                                    bgReading.save();
+                                    break;
+
+                                case DialogInterface.BUTTON_NEGATIVE:
+                                    bgReading.ignoreForStats = false;
+                                    bgReading.save();
+                                    break;
+                            }
+                        }
+                    };
+
+                    AlertDialog.Builder builder = new AlertDialog.Builder(context);
+                    builder.setMessage("Flag reading as \"bad\".\n Flagged readings have no impact on the statistics.").setPositiveButton("Yes", dialogClickListener)
+                            .setNegativeButton("No", dialogClickListener).show();
+                    return true;
+                }
+            });
         }
 
         @Override

--- a/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Tables/BgReadingTable.java
@@ -119,7 +119,7 @@ public class BgReadingTable extends ListActivity implements NavigationDrawerFrag
                     };
 
                     AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                    builder.setMessage("Flag reading as \"bad\".\n Flagged readings have no impact on the statistics.").setPositiveButton("Yes", dialogClickListener)
+                    builder.setMessage("Flag reading as \"bad\".\nFlagged readings have no impact on the statistics.").setPositiveButton("Yes", dialogClickListener)
                             .setNegativeButton("No", dialogClickListener).show();
                     return true;
                 }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/DBSearchUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/DBSearchUtil.java
@@ -22,7 +22,7 @@ import java.util.Vector;
  */
 public class DBSearchUtil {
 
-    public static final String CUTOFF = "13";
+    public static final String CUTOFF = "39";
 
 
     public static int noReadingsAboveRange(Context context) {
@@ -41,7 +41,8 @@ public class DBSearchUtil {
                 .where("timestamp >= " + bounds.start)
                 .where("timestamp <= " + bounds.stop)
                 .where("calculated_value > " + CUTOFF)
-                .where("calculated_value > " + high).count();
+                .where("calculated_value > " + high)
+                .where("snyced == 0").count();
         Log.d("DrawStats", "High count: " + count);
         return count;
     }
@@ -53,7 +54,7 @@ public class DBSearchUtil {
         String orderBy = ordered ? "calculated_value desc" : null;
 
         SQLiteDatabase db = Cache.openDatabase();
-        Cursor cur = db.query("bgreadings", new String[]{"timestamp", "calculated_value"}, "timestamp >= ? AND timestamp <=  ? AND calculated_value > ?", new String[]{"" + bounds.start, "" + bounds.stop, CUTOFF}, null, null, orderBy);
+        Cursor cur = db.query("bgreadings", new String[]{"timestamp", "calculated_value"}, "timestamp >= ? AND timestamp <=  ? AND calculated_value > ? AND snyced == 0", new String[]{"" + bounds.start, "" + bounds.stop, CUTOFF}, null, null, orderBy);
         List<BgReadingStats> readings = new Vector<BgReadingStats>();
         BgReadingStats reading;
         if (cur.moveToFirst()) {
@@ -89,6 +90,7 @@ public class DBSearchUtil {
                 .where("calculated_value > " + CUTOFF)
                 .where("calculated_value <= " + high)
                 .where("calculated_value >= " + low)
+                .where("snyced == 0")
                 .count();
         Log.d("DrawStats", "In count: " + count);
 
@@ -112,6 +114,7 @@ public class DBSearchUtil {
                 .where("timestamp <= " + bounds.stop)
                 .where("calculated_value > " + CUTOFF)
                 .where("calculated_value < " + low)
+                .where("snyced == 0")
                 .count();
         Log.d("DrawStats", "Low count: " + count);
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/stats/StatsResult.java
@@ -35,23 +35,23 @@ public class StatsResult {
         long today = DBSearchUtil.getTodayTimestamp();
         SQLiteDatabase db = Cache.openDatabase();
 
-        Cursor cursor= db.rawQuery("select count(*) from bgreadings  where timestamp >= " + today + " AND calculated_value >= " + low + " AND calculated_value <= " + high, null);
+        Cursor cursor= db.rawQuery("select count(*) from bgreadings  where timestamp >= " + today + " AND calculated_value >= " + low + " AND calculated_value <= " + high + " AND snyced == 0", null);
         cursor.moveToFirst();
         in = cursor.getInt(0);
         cursor.close();
 
-        cursor= db.rawQuery("select count(*) from bgreadings  where timestamp >= " + today + " AND calculated_value > " + DBSearchUtil.CUTOFF + " AND calculated_value < " + low, null);
+        cursor= db.rawQuery("select count(*) from bgreadings  where timestamp >= " + today + " AND calculated_value > " + DBSearchUtil.CUTOFF + " AND calculated_value < " + low + " AND snyced == 0", null);
         cursor.moveToFirst();
         below = cursor.getInt(0);
         cursor.close();
 
-        cursor= db.rawQuery("select count(*) from bgreadings  where timestamp >= " + today + " AND calculated_value > " + high, null);
+        cursor= db.rawQuery("select count(*) from bgreadings  where timestamp >= " + today + " AND calculated_value > " + high + " AND snyced == 0", null);
         cursor.moveToFirst();
         above = cursor.getInt(0);
         cursor.close();
 
         if(getTotalReadings() > 0){
-            cursor= db.rawQuery("select avg(calculated_value) from bgreadings  where timestamp >= " + today + " AND calculated_value > " + DBSearchUtil.CUTOFF, null);
+            cursor= db.rawQuery("select avg(calculated_value) from bgreadings  where timestamp >= " + today + " AND calculated_value > " + DBSearchUtil.CUTOFF + " AND snyced == 0", null);
             cursor.moveToFirst();
             avg = cursor.getDouble(0);
             cursor.close();


### PR DESCRIPTION
Long-press entry in BG-Data-Table to flag/unflag a reading.
Useful for fake high readings after transmitter swap or clear compression lows.

It does not change the behaviour regarding uploads/broadcasts to Nightscout or other apps nor the display of the values on the home screen.
