### PR TITLE
Less distance between title and info

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -3,18 +3,12 @@
     android:layout_width="match_parent" android:layout_height="match_parent"
     tools:context="com.eveningoutpost.dexdrip.Home">
 
-    <!-- As the main content view, the view below consumes the entire
-         space available using match_parent in both dimensions. -->
-    <FrameLayout android:id="@+id/container" android:layout_width="match_parent"
-        android:layout_height="match_parent" >
-
-    </FrameLayout>
-
         <LinearLayout
             android:orientation="vertical"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:background="#212121">
+            android:background="#212121"
+            android:paddingTop="-40dp">
 
             <RelativeLayout
                 android:layout_width="match_parent"
@@ -36,11 +30,13 @@
                 <TextView
                     android:layout_width="900dp"
                     android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textSize="14dp"
                     android:textColor="#FF0000"
                     android:id="@+id/notices"
                     android:paddingEnd="10dp"
                     android:paddingStart="10dp"
+                    android:layout_marginTop="-15dp"
+                    android:paddingTop="-15dp"
                     android:gravity="left|top"
                     android:layout_alignParentLeft="true"
                     android:text="Messages"
@@ -55,8 +51,9 @@
                     android:gravity="right"
                     android:layout_alignParentEnd="true"
                     android:paddingEnd="20dp"
+                    android:paddingTop="-15dp"
+                    android:layout_marginTop="-15dp"
                     android:textSize="50dp"
-                    android:paddingTop="0dp"
                     android:background="@android:color/transparent"/>
 
                 <TextView


### PR DESCRIPTION
The distance between the title/icon (action bar) and the info texts "minute ago" and BG value always has been quite large:
![screenshot_2016-08-21-12-09-46](https://cloud.githubusercontent.com/assets/9692866/18132758/4e8ee6ec-6f98-11e6-8d3c-c2b99b37fa72.png)

Now it looks like:
![screenshot_2016-08-31-16-19-00](https://cloud.githubusercontent.com/assets/9692866/18132799/7d0ad88c-6f98-11e6-8054-e23003838c57.png)

This is much space on a small phone that now can even be rotated:
![screenshot_2016-08-31-16-20-22](https://cloud.githubusercontent.com/assets/9692866/18132829/978041a2-6f98-11e6-90d7-da7689c3d2d8.png)

Please test on larger phones! Thanks.
